### PR TITLE
Fix FO4 when checking CK installation (#92)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 - Fix the new version popup background in light theme
 
+- FO4 support - Creation Kit installation
+
+  PCA was checking your Creation Kit installation by searching for `YOUR_GAME/Data/Scripts/Source/Actor.psc` file.
+
+  This was invalid because Fallout 4 use `YOUR_GAME/Data/Scripts/Source/Base/Actor.psc`
+
 ## 5.5.1 (2021-03-18)
 
 ### Bug fixes

--- a/src/common/game.ts
+++ b/src/common/game.ts
@@ -8,6 +8,7 @@ export type GamePath = string
 export type CompilerPath = string
 export type OutputPath = string
 export type Flag = 'TESV_Papyrus_Flags.flg' | 'Institute_Papyrus_Flags.flg'
+export type CompilerSourceFile = 'Actor.psc' | 'Base/Actor.psc'
 
 export enum GameSource {
   ScriptsFirst = 'Scripts/Source',
@@ -66,5 +67,14 @@ export function toExecutable(game: GameType): Executable {
       return Executable.Fo4
     default:
       return Executable.Se
+  }
+}
+
+export function toCompilerSourceFile(game: GameType): CompilerSourceFile {
+  switch (game) {
+    case GameType.Fo4:
+      return 'Base/Actor.psc'
+    default:
+      return 'Actor.psc'
   }
 }

--- a/src/main/event-handlers/check-installation.handler.ts
+++ b/src/main/event-handlers/check-installation.handler.ts
@@ -7,7 +7,9 @@
 import is from '@sindresorhus/is'
 
 import {
+  CompilerSourceFile,
   GameType,
+  toCompilerSourceFile,
   toExecutable,
   toOtherSource,
   toSource
@@ -35,7 +37,8 @@ export class CheckInstallationHandler implements EventHandler {
       return hasCompiler
     }
 
-    const file = 'Actor.psc'
+    const gameType = appStore.get('game').type
+    const file = toCompilerSourceFile(gameType)
     const isUsingMo2: boolean = appStore.get('mo2.use')
 
     if (isUsingMo2) {
@@ -81,7 +84,7 @@ export class CheckInstallationHandler implements EventHandler {
     return result
   }
 
-  private async checkInMo2(file: string): Promise<BadError> {
+  private async checkInMo2(file: CompilerSourceFile): Promise<BadError> {
     const gameType: GameType = appStore.get('game.type')
     const mo2 = appStore.get('mo2')
 

--- a/src/renderer/pages/settings/settings-game.tsx
+++ b/src/renderer/pages/settings/settings-game.tsx
@@ -12,7 +12,11 @@ import RefreshIcon from '@material-ui/icons/Refresh'
 import React from 'react'
 import { useTranslation } from 'react-i18next'
 
-import { GameType, toExecutable } from '../../../common/game'
+import {
+  GameType,
+  toCompilerSourceFile,
+  toExecutable
+} from '../../../common/game'
 import { Alert } from '../../components/alert'
 import { DialogTextField } from '../../components/dialog/dialog-text-field'
 import { useApp } from '../../hooks/use-app'
@@ -120,7 +124,9 @@ export function SettingsGame({
                   compilerExe: compilation.compilerPath
                 })}
               {isBadInstallation === 'scripts' &&
-                t('page.settings.errors.scripts')}
+                t('page.settings.errors.scripts', {
+                  file: toCompilerSourceFile(game.type)
+                })}
             </p>
           </div>
           <div>

--- a/src/renderer/translations/en.ts
+++ b/src/renderer/translations/en.ts
@@ -60,7 +60,7 @@ const en = {
       errors: {
         installationInvalid: 'Configuration seems invalid:',
         scripts:
-          "Check that your Creation Kit installation is valid. The app checks the presence of Actor.psc file in Scripts\\Source or Source\\Scripts folders to validate your Creation Kit installation. If you're using the app MO2 integration, the folders overwrite and mods are also checked.",
+          "Check that your Creation Kit installation is valid. The app checks the presence of {{file}} file in Scripts\\Source or Source\\Scripts folders to validate your Creation Kit installation. If you're using the app MO2 integration, the folders overwrite and mods are also checked.",
         game: 'Check that "{{exe}}" exists in the game folder.',
         compiler: 'Check that "{{compilerExe}}" exists.',
         mo2Instance: 'Check that instance folder "{{mo2Instance}}" exists.'

--- a/src/renderer/translations/fr.ts
+++ b/src/renderer/translations/fr.ts
@@ -61,7 +61,7 @@ const fr = {
       errors: {
         installationInvalid: 'La configuration semble invalide :',
         scripts:
-          "Vérifiez que votre installation de Creation Kit est valide. L'application vérifie la présence du fichier Actor.psc dans les dossiers Scripts\\Source ou Source\\Scripts pour valider l'installation de votre Creation Kit. Si vous utilisez l'integration MO2 de l'application, les dossiers overwrite et mods sont également vérifiés.",
+          "Vérifiez que votre installation de Creation Kit est valide. L'application vérifie la présence du fichier {{file}} dans les dossiers Scripts\\Source ou Source\\Scripts pour valider l'installation de votre Creation Kit. Si vous utilisez l'integration MO2 de l'application, les dossiers overwrite et mods sont également vérifiés.",
         game: 'Vérifiez que "{{exe}}" existe dans le dossier du jeu.',
         compiler: 'Vérifiez que "{{compilerExe}}" existe.',
         mo2Instance:

--- a/var/Fallout4/Data/Source/Scripts/Base/Actor.psc
+++ b/var/Fallout4/Data/Source/Scripts/Base/Actor.psc
@@ -1,0 +1,5 @@
+Scriptname Actor extends Quest
+
+Function test()
+
+EndFunction

--- a/var/Fallout4/Data/Source/Scripts/Data.psc
+++ b/var/Fallout4/Data/Source/Scripts/Data.psc
@@ -1,0 +1,5 @@
+Scriptname Data extends Quest
+
+Function test()
+
+EndFunction

--- a/var/Fallout4/Papyrus Compiler/PapyrusCompiler.exe
+++ b/var/Fallout4/Papyrus Compiler/PapyrusCompiler.exe
@@ -1,0 +1,10 @@
+#!/usr/bin/env node
+/* eslint-disable no-undef */
+
+/*
+ * Copyright (c) 2021 Kiyozz.
+ *
+ * All rights reserved.
+ */
+
+console.log('Batch compile of 1 files finished. 1 succeeded, 0 failed.')


### PR DESCRIPTION
Closes #92 

- FO4 support - Creation Kit installation

  PCA was checking your Creation Kit installation by searching for `YOUR_GAME/Data/Scripts/Source/Actor.psc` file.

  This was invalid because Fallout 4 use `YOUR_GAME/Data/Scripts/Source/Base/Actor.psc`
