### PR TITLE
feat(compilation): papyrus namespaces, fo4 import roots, starfield fixes

### DIFF
--- a/.changeset/0016-papyrus-namespace.md
+++ b/.changeset/0016-papyrus-namespace.md
@@ -1,0 +1,5 @@
+---
+'pca': minor
+---
+
+Support Papyrus namespaces (Fallout 4, Starfield). The namespace declared in the psc header (`Scriptname MyMod:Script`) is now given to the compiler, the namespace root folder is imported instead of the script folder, and the pex is written to its namespace subfolder. Duplicate imports are removed to keep the command line shorter.

--- a/.changeset/0016-papyrus-namespace.md
+++ b/.changeset/0016-papyrus-namespace.md
@@ -2,4 +2,6 @@
 'pca': minor
 ---
 
-Support Papyrus namespaces (Fallout 4, Starfield). The namespace declared in the psc header (`Scriptname MyMod:Script`) is now given to the compiler, the namespace root folder is imported instead of the script folder, and the pex is written to its namespace subfolder. Duplicate imports are removed to keep the command line shorter.
+Support Papyrus namespaces (Fallout 4, Starfield). The namespace declared in the psc header (`Scriptname MyMod01:Script`) is now given to the compiler, the namespace root folder is imported instead of the script folder, and the pex is written to its namespace subfolder.
+
+Fallout 4 imports are reduced to the three roots the game actually uses — `Scripts/Source`, `Scripts/Source/Base` and `Scripts/Source/User` — instead of globbing every subfolder four levels deep. Those subfolders are namespace folders, not roots: the compiler walks down to them on its own. On a stock Fallout 4 install this takes the command line from 64 imports to 4, which makes the `ENAMETOOLONG` limit much harder to hit.

--- a/.changeset/0017-starfield-fixes.md
+++ b/.changeset/0017-starfield-fixes.md
@@ -2,4 +2,6 @@
 'pca': minor
 ---
 
-Fix Starfield support, which could not compile anything: the game executable was looked up as `Startfield.exe`, its sources were expected in `Data/Source/Scripts` instead of `Data/Scripts/Source`, the config check looked for `Base/Actor.psc` when Starfield has no `Base` folder, and `Starfield_Papyrus_Flags.flg` was not a selectable flag. Starfield keeps every script under `Scripts/Source` — its subfolders are namespaces — so that folder is now its only import root.
+Fix Starfield support, which could not compile anything: the game executable was looked up as `Startfield.exe`, its sources were expected in `Data/Source/Scripts` instead of `Data/Scripts/Source`, the config check looked for `Base/Actor.psc` when Starfield has no `Base` folder, and `Starfield_Papyrus_Flags.flg` was not a selectable flag. Selecting Starfield in the settings also silently reverted to Skyrim: the store's game type check listed the four other games and reset anything else, so the choice was overwritten on the next config check while the game path and flag stayed on Starfield. It now reuses the shared `validateGame.gameType()` instead of its own outdated list.
+
+Starfield keeps every script under `Scripts/Source` — its subfolders are namespaces — so that folder is now its only import root.

--- a/.changeset/0017-starfield-fixes.md
+++ b/.changeset/0017-starfield-fixes.md
@@ -1,0 +1,5 @@
+---
+'pca': minor
+---
+
+Fix Starfield support, which could not compile anything: the game executable was looked up as `Startfield.exe`, its sources were expected in `Data/Source/Scripts` instead of `Data/Scripts/Source`, the config check looked for `Base/Actor.psc` when Starfield has no `Base` folder, and `Starfield_Papyrus_Flags.flg` was not a selectable flag. Starfield keeps every script under `Scripts/Source` — its subfolders are namespaces — so that folder is now its only import root.

--- a/package.json
+++ b/package.json
@@ -75,7 +75,6 @@
     "electron-tsdown": "^12.0.0",
     "electron-util": "~1.0.0",
     "emittery": "^2.0.0",
-    "fast-glob": "~3.3.3",
     "kkrpc": "^2.1.0",
     "lefthook": "^2.1.12",
     "lucide-react": "^1.35.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -137,9 +137,6 @@ importers:
       emittery:
         specifier: ^2.0.0
         version: 2.0.0
-      fast-glob:
-        specifier: ~3.3.3
-        version: 3.3.3
       kkrpc:
         specifier: ^2.1.0
         version: 2.1.0(hono@4.13.5)(typescript@7.0.2)

--- a/src/common/game.ts
+++ b/src/common/game.ts
@@ -7,7 +7,10 @@ import is from '@sindresorhus/is'
 export type GamePath = string
 export type CompilerPath = string
 export type OutputPath = string
-export type Flag = 'TESV_Papyrus_Flags.flg' | 'Institute_Papyrus_Flags.flg'
+export type Flag =
+  | 'TESV_Papyrus_Flags.flg'
+  | 'Institute_Papyrus_Flags.flg'
+  | 'Starfield_Papyrus_Flags.flg'
 export type CompilerSourceFile = 'Actor.psc' | 'Base/Actor.psc'
 
 export enum GameSource {
@@ -20,7 +23,7 @@ export enum Executable {
   le = 'TESV.exe',
   vr = 'SkyrimVR.exe',
   fo4 = 'Fallout4.exe',
-  sf = 'Startfield.exe',
+  sf = 'Starfield.exe',
 }
 
 export enum GameType {
@@ -35,10 +38,10 @@ export const toSource = (game: GameType): GameSource => {
   switch (game) {
     case GameType.le:
     case GameType.fo4:
+    case GameType.sf:
       return GameSource.scriptsFirst
     case GameType.se:
     case GameType.vr:
-    case GameType.sf:
       return GameSource.sourceFirst
     default:
       throw new Error('RuntimeError: unsupported GameType')
@@ -49,10 +52,10 @@ export const toOtherSource = (game: GameType): GameSource => {
   switch (game) {
     case GameType.le:
     case GameType.fo4:
+    case GameType.sf:
       return GameSource.sourceFirst
     case GameType.se:
     case GameType.vr:
-    case GameType.sf:
       return GameSource.scriptsFirst
     default:
       throw new Error('RuntimeError: unsupported GameType')
@@ -79,14 +82,34 @@ export const toExecutable = (game: GameType): Executable => {
 export const toCompilerSourceFile = (game: GameType): CompilerSourceFile => {
   switch (game) {
     case GameType.fo4:
-    case GameType.sf:
       return 'Base/Actor.psc'
     default:
       return 'Actor.psc'
   }
 }
 
+export const toFlag = (game: GameType): Flag => {
+  switch (game) {
+    case GameType.fo4:
+      return 'Institute_Papyrus_Flags.flg'
+    case GameType.sf:
+      return 'Starfield_Papyrus_Flags.flg'
+    default:
+      return 'TESV_Papyrus_Flags.flg'
+  }
+}
+
 export const validateGame = {
+  flag: (flag?: Flag | string): flag is Flag => {
+    switch (flag) {
+      case 'TESV_Papyrus_Flags.flg':
+      case 'Institute_Papyrus_Flags.flg':
+      case 'Starfield_Papyrus_Flags.flg':
+        return true
+    }
+
+    return false
+  },
   gameType: (type?: GameType): type is GameType => {
     if (is.undefined(type)) return false
 

--- a/src/main/compilation/compile.ts
+++ b/src/main/compilation/compile.ts
@@ -94,12 +94,15 @@ class PapyrusCompilerService implements Compiler {
 
     await path.ensureDirs([gameSourceAbsolute, runner.output])
 
-    const otherSource = toOtherSource(gameType)
-    const otherSourceAbsolute = path.join(dataFolder, otherSource)
+    if (gameType === GameType.sf) {
+      // sf keeps every script under Scripts/Source, with no Base nor User
+      // folder: its subfolders are namespaces, so that is the only root.
+      this.#logger.debug('import of the sf source root')
 
-    this.#logger.debug('other game source', otherSourceAbsolute)
-
-    if (gameType === GameType.fo4) {
+      runner.imports = [importDir, gameSourceAbsolute].filter((i) =>
+        path.exists(i),
+      )
+    } else if (gameType === GameType.fo4) {
       // fo4 kept the le layout (Scripts/Source) and turned its subfolders into
       // namespaces, so only Source, Source/Base and Source/User are roots: the
       // compiler walks down to the namespace folders on its own.
@@ -111,10 +114,17 @@ class PapyrusCompilerService implements Compiler {
         path.join(gameSourceAbsolute, 'Base'),
         path.join(gameSourceAbsolute, 'User'),
       ].filter((i) => path.exists(i))
-    } else if (path.exists(otherSourceAbsolute)) {
-      this.#logger.debug(`import of the ${otherSource} folder`)
+    } else {
+      const otherSource = toOtherSource(gameType)
+      const otherSourceAbsolute = path.join(dataFolder, otherSource)
 
-      runner.imports = [importDir, otherSourceAbsolute, gameSourceAbsolute]
+      this.#logger.debug('other game source', otherSourceAbsolute)
+
+      if (path.exists(otherSourceAbsolute)) {
+        this.#logger.debug(`import of the ${otherSource} folder`)
+
+        runner.imports = [importDir, otherSourceAbsolute, gameSourceAbsolute]
+      }
     }
 
     runner.imports = uniqImports(runner.imports)

--- a/src/main/compilation/compile.ts
+++ b/src/main/compilation/compile.ts
@@ -99,26 +99,22 @@ class PapyrusCompilerService implements Compiler {
 
     this.#logger.debug('other game source', otherSourceAbsolute)
 
-    if (path.exists(otherSourceAbsolute)) {
-      this.#logger.debug(`import of the ${otherSource} folder`)
-
-      runner.imports = [importDir, otherSourceAbsolute, gameSourceAbsolute]
-    }
-
     if (gameType === GameType.fo4) {
-      this.#logger.debug('import of fo4 sources')
+      // fo4 kept the le layout (Scripts/Source) and turned its subfolders into
+      // namespaces, so only Source, Source/Base and Source/User are roots: the
+      // compiler walks down to the namespace folders on its own.
+      this.#logger.debug('import of fo4 source roots')
 
       runner.imports = [
         importDir,
-        ...(await path.getPathsInFolder(
-          [`${gamePath}/Data/Scripts/Source/**`],
-          {
-            onlyDirectories: true,
-            deep: 4,
-          },
-        )),
-        ...runner.imports.filter((i) => i !== importDir),
-      ]
+        gameSourceAbsolute,
+        path.join(gameSourceAbsolute, 'Base'),
+        path.join(gameSourceAbsolute, 'User'),
+      ].filter((i) => path.exists(i))
+    } else if (path.exists(otherSourceAbsolute)) {
+      this.#logger.debug(`import of the ${otherSource} folder`)
+
+      runner.imports = [importDir, otherSourceAbsolute, gameSourceAbsolute]
     }
 
     runner.imports = uniqImports(runner.imports)

--- a/src/main/compilation/compile.ts
+++ b/src/main/compilation/compile.ts
@@ -17,7 +17,14 @@ import { SettingsStore } from '../store/settings/store'
 import { generateCompilerCmd } from '../utils/generate-compiler-cmd.util'
 import type { ExecException } from '../exceptions/exec.exception'
 import { Compiler } from '#main/compilation/compiler.ts'
+import type { CompileResult } from '#main/compilation/compiler.ts'
 import { inject } from '#main/inject.ts'
+import { toSlash } from '../slash'
+import { resolveScript } from '../utils/script-namespace.util'
+
+const uniqImports = (imports: string[]): string[] => [
+  ...new Map(imports.map((i) => [toSlash(i).toLowerCase(), i])).values(),
+]
 
 interface Runner {
   exe: string
@@ -35,11 +42,8 @@ class PapyrusCompilerService implements Compiler {
     this.#settingsStore = settingsStore
   }
 
-  async compile(scriptPath: string): Promise<string> {
+  async compile(scriptPath: string): Promise<CompileResult> {
     this.#logger.info('compiling', scriptPath)
-
-    const scriptName = path.basename(scriptPath)
-    const scriptDir = path.parentDir(scriptPath)
 
     const { path: gamePath, type: gameType } = this.#settingsStore.get('game')
     const {
@@ -47,6 +51,10 @@ class PapyrusCompilerService implements Compiler {
       compilerPath,
       flag,
     } = this.#settingsStore.get('compilation')
+    const { name: scriptName, importDir } = await resolveScript(
+      scriptPath,
+      gameType,
+    )
     const dataFolder = path.join(gamePath, 'Data')
     const gameSource = toSource(gameType)
     const gameSourceAbsolute = path.join(dataFolder, gameSource)
@@ -56,7 +64,7 @@ class PapyrusCompilerService implements Compiler {
         : outputPath
     const runner: Runner = {
       exe: compilerPath,
-      imports: [gameSourceAbsolute, scriptDir],
+      imports: [gameSourceAbsolute, importDir],
       cwd: gamePath,
       output: resolvedOutput,
     }
@@ -94,14 +102,14 @@ class PapyrusCompilerService implements Compiler {
     if (path.exists(otherSourceAbsolute)) {
       this.#logger.debug(`import of the ${otherSource} folder`)
 
-      runner.imports = [scriptDir, otherSourceAbsolute, gameSourceAbsolute]
+      runner.imports = [importDir, otherSourceAbsolute, gameSourceAbsolute]
     }
 
     if (gameType === GameType.fo4) {
       this.#logger.debug('import of fo4 sources')
 
       runner.imports = [
-        scriptDir,
+        importDir,
         ...(await path.getPathsInFolder(
           [`${gamePath}/Data/Scripts/Source/**`],
           {
@@ -109,9 +117,11 @@ class PapyrusCompilerService implements Compiler {
             deep: 4,
           },
         )),
-        ...runner.imports.filter((i) => i !== scriptDir),
+        ...runner.imports.filter((i) => i !== importDir),
       ]
     }
+
+    runner.imports = uniqImports(runner.imports)
 
     const cmd = generateCompilerCmd({
       exe: runner.exe,
@@ -128,7 +138,7 @@ class PapyrusCompilerService implements Compiler {
 
       this.#checkCommandResult(scriptName, result)
 
-      return result.stdout.trim()
+      return { output: result.stdout.trim(), name: scriptName }
     } catch (err) {
       if (err instanceof CompilationException) {
         throw err

--- a/src/main/compilation/compiler.ts
+++ b/src/main/compilation/compiler.ts
@@ -2,6 +2,13 @@
  * 2026 Kiyozz.
  */
 
+export interface CompileResult {
+  /** raw compiler output */
+  output: string
+  /** name given to the compiler, namespaced when the script declares one */
+  name: string
+}
+
 export abstract class Compiler {
-  abstract compile(scriptPath: string): Promise<string>
+  abstract compile(scriptPath: string): Promise<CompileResult>
 }

--- a/src/main/event-handlers/script-compile.event.ts
+++ b/src/main/event-handlers/script-compile.event.ts
@@ -6,6 +6,7 @@ import is from '@sindresorhus/is'
 import { Logger } from '../logger'
 import { SettingsStore } from '../store/settings/store'
 import { ApplicationException } from '../exceptions/application.exception'
+import { CompilationException } from '../exceptions/compilation.exception'
 import { fromError } from '#common/from-error.ts'
 import type { CompilationResult } from '#common/types/compilation-result.ts'
 import { inject } from '#main/inject.ts'
@@ -63,18 +64,22 @@ export class ScriptCompileEvent {
     const scriptName = basename(scriptPath)
 
     try {
-      const result = ScriptCompileEvent._cleanSuccessLog(
-        scriptName,
-        await this.#compiler.compile(scriptPath),
-      )
+      const { output, name } = await this.#compiler.compile(scriptPath)
 
-      return { success: true, output: result, script: scriptName }
+      return {
+        success: true,
+        output: ScriptCompileEvent._cleanSuccessLog(name, output),
+        script: scriptName,
+      }
     } catch (e) {
       const errorMessage: string = fromError(e).message
+      // the compiler logs the namespaced name, not the file name
+      const compiledName =
+        e instanceof CompilationException ? e.script : scriptName
 
       return {
         success: false,
-        output: ScriptCompileEvent._cleanErrorLog(scriptName, errorMessage),
+        output: ScriptCompileEvent._cleanErrorLog(compiledName, errorMessage),
         script: scriptName,
       }
     }

--- a/src/main/exceptions/compilation.exception.ts
+++ b/src/main/exceptions/compilation.exception.ts
@@ -3,9 +3,13 @@
  */
 
 export class CompilationException extends Error {
+  readonly script: string
+
   constructor(script: string, err: string) {
     const removedString = `Script ${script} failed to compile: `
 
     super(`${removedString}${err.replace(removedString, '')}`)
+
+    this.script = script
   }
 }

--- a/src/main/path/path.ts
+++ b/src/main/path/path.ts
@@ -6,12 +6,10 @@ import { promises as fs, existsSync } from 'node:fs'
 import * as path from 'node:path'
 import * as url from 'node:url'
 import { is } from 'electron-util'
-import fg from 'fast-glob'
 import { moveFile } from 'move-file'
 import { FileAccessException } from '../exceptions/files/file-access.exception'
 import { FileEnsureException } from '../exceptions/files/file-ensure.exception'
 import { Logger } from '../logger'
-import { toSlash } from '../slash'
 import { pluralize } from '../utils/pluralize.util'
 import type { Stats } from 'node:fs'
 
@@ -113,28 +111,4 @@ export async function ensureFiles(items: string[]): Promise<void> {
       }
     }),
   )
-}
-
-export async function getPathsInFolder(
-  fileNames: string[],
-  options: fg.Options = {},
-): Promise<string[]> {
-  logger.debug(
-    'retrieving paths from the folders',
-    fileNames,
-    'with options',
-    options,
-  )
-
-  const response = await fg(
-    fileNames.map((file) => toSlash(file)),
-    {
-      caseSensitiveMatch: false,
-      ...options,
-    },
-  )
-
-  logger.debug('response of fast-glob', response)
-
-  return response
 }

--- a/src/main/store/settings/store.ts
+++ b/src/main/store/settings/store.ts
@@ -97,18 +97,8 @@ class SettingsStore extends Store<Config> {
       return
     }
 
-    if (!is.string(gameType)) {
+    if (!validateGame.gameType(gameType)) {
       resetGameType()
-    }
-
-    switch (gameType) {
-      case GameType.fo4:
-      case GameType.le:
-      case GameType.se:
-      case GameType.vr:
-        break
-      default:
-        resetGameType()
     }
   }
 

--- a/src/main/store/settings/store.ts
+++ b/src/main/store/settings/store.ts
@@ -11,6 +11,7 @@ import {
   type Flag,
   type GamePath,
   GameType,
+  toFlag,
   validateGame,
 } from '#common/game.ts'
 import { LogLevel } from '#common/log-level.ts'
@@ -132,18 +133,10 @@ class SettingsStore extends Store<Config> {
   #checkFlag() {
     const flag = this.get<string, Flag | string>('compilation.flag')
 
-    if (
-      flag !== 'TESV_Papyrus_Flags.flg' &&
-      flag !== 'Institute_Papyrus_Flags.flg'
-    ) {
+    if (!validateGame.flag(flag)) {
       this.#logger.warn(flag, 'is not supported')
 
-      this.set(
-        'compilation.flag',
-        this.get('game.type') === GameType.fo4
-          ? 'Institute_Papyrus_Flags.flg'
-          : defaultSettingsStoreConfig.compilation.flag,
-      )
+      this.set('compilation.flag', toFlag(this.get('game.type')))
     }
   }
 

--- a/src/main/utils/script-namespace.util.ts
+++ b/src/main/utils/script-namespace.util.ts
@@ -1,0 +1,137 @@
+/*
+ * 2026 Kiyozz.
+ */
+
+import { GameType } from '#common/game.ts'
+import { Logger } from '../logger'
+import * as path from '../path/path'
+import { toSlash } from '../slash'
+
+const logger = new Logger('ScriptNamespace')
+
+const namespaceGames = new Set<GameType>([GameType.fo4, GameType.sf])
+
+/**
+ * First line of the script that is not a comment nor empty. The `ScriptName`
+ * declaration is always the first statement of a psc file.
+ */
+function firstStatement(content: string): string | undefined {
+  let inBlockComment = false
+
+  for (const rawLine of content.split(/\r?\n/)) {
+    const line = rawLine.trim()
+
+    if (inBlockComment) {
+      inBlockComment = !line.includes('/;')
+      continue
+    }
+
+    if (line.startsWith(';/')) {
+      inBlockComment = !line.slice(2).includes('/;')
+      continue
+    }
+
+    if (line === '' || line.startsWith(';')) continue
+
+    return line
+  }
+
+  return undefined
+}
+
+/**
+ * `Scriptname Mod:Sub:Script extends Form` -> `Mod:Sub`
+ */
+async function readNamespace(scriptPath: string): Promise<string | undefined> {
+  let content: string
+
+  try {
+    content = await path.readFile(scriptPath, 'utf8')
+  } catch (e) {
+    logger.warn('cannot read the script header', scriptPath, e)
+
+    return undefined
+  }
+
+  const statement = firstStatement(content)
+
+  if (statement === undefined) return undefined
+
+  const declaration = /^scriptname\s+(?<name>[\w:]+)/i.exec(statement)
+  const name = declaration?.groups?.name
+
+  if (name === undefined || !name.includes(':')) return undefined
+
+  return name.slice(0, name.lastIndexOf(':'))
+}
+
+/**
+ * The compiler resolves `Mod:Script` as `<import>/Mod/Script.psc`, so the
+ * folders of the script must mirror its namespace.
+ */
+function isInNamespaceFolders(scriptDir: string, parts: string[]): boolean {
+  const segments = toSlash(scriptDir)
+    .split('/')
+    .filter((segment) => segment !== '')
+
+  if (segments.length < parts.length) return false
+
+  return segments
+    .slice(-parts.length)
+    .every((segment, i) => segment.toLowerCase() === parts[i]?.toLowerCase())
+}
+
+interface ResolvedScript {
+  /** name given to the compiler: `Mod:Script` when namespaced, the file name otherwise */
+  name: string
+  /** folder to import: the namespace root when namespaced, the script folder otherwise */
+  importDir: string
+  namespace: string | undefined
+}
+
+/**
+ * Namespaces exist since Fallout 4. The namespace is declared in the psc
+ * header and drives both the name given to the compiler and the subfolder the
+ * pex is written to.
+ */
+async function resolveScript(
+  scriptPath: string,
+  game: GameType,
+): Promise<ResolvedScript> {
+  const fileName = path.basename(scriptPath)
+  const scriptDir = path.parentDir(scriptPath)
+  const withoutNamespace: ResolvedScript = {
+    name: fileName,
+    importDir: scriptDir,
+    namespace: undefined,
+  }
+
+  if (!namespaceGames.has(game)) return withoutNamespace
+
+  const namespace = await readNamespace(scriptPath)
+
+  if (namespace === undefined) return withoutNamespace
+
+  const parts = namespace.split(':')
+
+  if (!isInNamespaceFolders(scriptDir, parts)) {
+    logger.warn(
+      `"${fileName}" declares the namespace "${namespace}" but "${scriptDir}" does not match it, compiling without namespace`,
+    )
+
+    return withoutNamespace
+  }
+
+  const resolved: ResolvedScript = {
+    name: `${namespace}:${fileName.replace(/\.psc$/i, '')}`,
+    importDir: path.join(scriptDir, ...parts.map(() => '..')),
+    namespace,
+  }
+
+  logger.debug('resolved namespaced script', resolved)
+
+  return resolved
+}
+
+export { resolveScript }
+export type { ResolvedScript }

--- a/src/renderer/pages/settings/settings-page.tsx
+++ b/src/renderer/pages/settings/settings-page.tsx
@@ -22,7 +22,7 @@ import debounce from 'debounce-fn'
 import { BookIcon, RotateCcwIcon } from 'lucide-react'
 import { useCallback, useEffect, useMemo } from 'react'
 import { useForm } from 'react-hook-form'
-import { GameType } from '#common/game.ts'
+import { GameType, toFlag } from '#common/game.ts'
 import { LogLevel } from '#common/log-level.ts'
 import { TelemetryEvent } from '#common/telemetry-event.ts'
 import { Theme } from '#common/theme.ts'
@@ -133,10 +133,7 @@ export function SettingsPage() {
             setConfig({
               game: { type: gameType },
               compilation: {
-                flag:
-                  gameType === GameType.fo4
-                    ? 'Institute_Papyrus_Flags.flg'
-                    : 'TESV_Papyrus_Flags.flg',
+                flag: toFlag(gameType),
               },
             })
 


### PR DESCRIPTION
## Issues

Closes #158

## Description

Papyrus namespaces exist since Fallout 4 (and Starfield). PCA ignored them: it passed the file basename to the compiler and imported the folder holding the psc, so `Scripts/Source/User/MyMod01/MyScript.psc` was written to `Scripts/MyScript.pex` instead of `Scripts/MyMod01/MyScript.pex` — and a script declaring `Scriptname MyMod01:MyScript` did not resolve at all.

**Namespace resolution.** New `resolveScript(scriptPath, game)` (`src/main/utils/script-namespace.util.ts`) reads the namespace from the psc header:

- skips comments (`;`, `;/ … /;` blocks) and blank lines, then matches `Scriptname <Ns:Sub:Name>` on the first statement
- checks the folders mirror the namespace (case-insensitive); on mismatch it logs a warning and falls back to the previous behaviour, letting the compiler report the real error
- returns the qualified name (`MyMod01:MyScript`) and the namespace root to import (`Scripts/Source/User`) instead of the leaf folder
- no-op outside Fallout 4 / Starfield

`Compiler.compile()` now returns `{ output, name }` and `CompilationException` exposes `script`, so the log cleanup in `ScriptCompileEvent` matches what the compiler actually prints (`Compiling "MyMod01:MyScript"...`) — the previous `.replace()` calls were anchored on the basename. `CompilationResult.script` still carries the file name for the UI.

**Fallout 4 imports.** Same subject, so it ships here: the fo4 branch used to glob every subfolder of `Scripts/Source` four levels deep. Those subfolders are namespace folders, not import roots — the compiler walks down to them by itself once it has the root. Fallout 4 has exactly three roots, confirmed against a stock install's `CreationKit.ini` (`sScriptSourceFolder = ".\Data\Scripts\Source\User"`, `sAdditionalImports = "$(source);.\Data\Scripts\Source\Base"`) and against the vanilla script headers:

| script | header | root |
| --- | --- | --- |
| `Source/Base/AODogmeatQuestScript.psc` | `Scriptname AODogmeatQuestScript` | `Source/Base` |
| `Source/Base/Hardcore/HC_*.psc` | `Scriptname Hardcore:HC_*` | `Source/Base` |
| `Source/Base/Fragments/Quests/QF_*.psc` | `Scriptname Fragments:Quests:QF_*` | `Source/Base` |
| `Source/DLC01/*.psc` | `Scriptname DLC01:*` | `Source` |
| `Source/CreationClub/Fragments/Perks/PRKF_*.psc` | `Scriptname CreationClub:Fragments:Perks:PRKF_*` | `Source` |
| `Source/User/MyMod01/*.psc` | `Scriptname MyMod01:*` | `Source/User` |

Note this is the Creation Kit's default plus one: the CK ships with `Source/User` and `Source/Base` only, which is why every Fallout 4 guide tells modders to add `Scripts/Source` to `sAdditionalImports` by hand — without it nothing extending a DLC or Creation Club script resolves. PCA does it for them. The roots stay hardcoded rather than read from `CreationKit.ini`, so PCA keeps working with Papyrus compilers other than the CK's.

Imports are now `[scriptRoot, Source, Source/Base, Source/User]`, filtered on existence and deduplicated (case-insensitive, slash-normalised — the script root overlaps a game root in most cases). On a stock install the command line goes from **64 imports / 5535 characters to 4**, which makes the documented `ENAMETOOLONG` limit far harder to hit. The `Source/Scripts` import is also dropped for fo4: that is the Skyrim SE layout, and fo4 kept the LE one.

**Starfield.** The game turned out to be unable to compile anything at all, for reasons unrelated to namespaces, so the fixes ship here too:

| code | reality |
| --- | --- |
| `Executable.sf = 'Startfield.exe'` | `Starfield.exe` — the typo failed the `path.exists()` check before the compiler was ever reached |
| `toSource(sf) = Source/Scripts` | `Scripts/Source`, per `sScriptSourceFolder=Data/Scripts/Source/` |
| `toCompilerSourceFile(sf) = 'Base/Actor.psc'` | `Actor.psc` — Starfield has no `Base` folder |
| `Flag` had no Starfield value | `Starfield_Papyrus_Flags.flg` |

Starfield keeps its 1580 vanilla scripts flat under `Scripts/Source`, with subfolders used as namespaces (`Fragments:Quests:`, `SFBGS00D:`, `DLC03:Fragments:Quests:`, `FXScripts:`) and no `sAdditionalImports` in its `CreationKit.ini`, so it gets a single import root. Flag selection moved to a shared `toFlag(game)` used by both the settings page and the store check, instead of the two `fo4 ? … : …` ternaries that silently gave Starfield the Skyrim flag.

## Notes

Tested against real Fallout 4 and Starfield installs, both with their Creation Kit.

Through the app (namespace resolution, output layout, log cleanup):

| input | compiled name | pex |
| --- | --- | --- |
| `Source/User/MyMod01/MyScript.psc` | `MyMod01:MyScript` | `Output/MyMod01/MyScript.pex` |
| `Source/User/MyMod01/Deep/Other.psc` | `MyMod01:Deep:Other` | `Output/MyMod01/Deep/Other.pex` |
| `Source/CreationClub/Fragments/Perks/PRKF_CC_PetDogs_PetPerk_0024A158.psc` | `CreationClub:Fragments:Perks:PRKF_…` | `Output/CreationClub/Fragments/Perks/PRKF_….pex` |

Driving `PapyrusCompiler.exe` directly with only the three roots, to confirm the glob is dead weight — all succeeded, each pex landing in its namespace subfolder:

`CreationClub:Fragments:Perks:PRKF_CC_PetDogs_PetPerk_0024A158`, `DLC01:Fragments:Quests:QF_DLC01Achievements_01010A55`, `AODogmeatQuestScript`, `Fragments:Quests:QF_AO_CIS_Manager_00175526`, `Hardcore:HC_CaffeinatedEffectScript`, `MyMod01:MyScript`, `MyMod01:Deep:Other`.

Same exercise for Starfield, driving its compiler with the single root and `Starfield_Papyrus_Flags.flg` — all succeeded, each pex in its namespace subfolder: `AchievementsScript` (flat, no namespace), `Fragments:Quests:QF_Achievements_PlayerLevelT_0029E181`, `SFBGS00D:ActionFigureAchievementScript`, `FXScripts:CameraAttachScriptFX`, `DLC03:Fragments:Quests:QF_SFBGS003_BountyScannerQ_FD0066B3_1`.

Starfield ships its sources in `Tools/ContentResources.zip` rather than installed on disk; they have to be extracted into `Data/` to get `Data/Scripts/Source/`.

`path.getPathsInFolder()` lost its last caller and is removed, along with the `fast-glob` dependency.

Known limitation, pre-existing: a mod whose sources live in `Scripts/Source/<folder>/` **without** a namespace in the header no longer gets that folder imported for its *dependencies*. The compiled script itself is still covered (its own folder is the resolved root). The Creation Kit would not support that layout either.
