### PR TITLE
fix(compilation): re-enable add scripts button when file picker is cancelled

### DIFF
--- a/.changeset/0018-file-dialog-cancel.md
+++ b/.changeset/0018-file-dialog-cancel.md
@@ -1,0 +1,5 @@
+---
+'pca': patch
+---
+
+Fix the add scripts button staying disabled after closing the file picker without selecting anything. The picker fires `cancel` in that case, never `change`, so the flag tracking the open dialog was never cleared.

--- a/src/renderer/components/drop/drop-scripts.tsx
+++ b/src/renderer/components/drop/drop-scripts.tsx
@@ -3,7 +3,7 @@
  */
 
 import cx from 'classnames'
-import React, { useCallback, useRef } from 'react'
+import React, { useCallback, useEffect, useRef } from 'react'
 import { useDropzone } from '#/hooks/use-dropzone.ts'
 
 interface RenderChildren {
@@ -35,6 +35,20 @@ function DropScripts({
   })
 
   const inputRef = useRef<HTMLInputElement>(null)
+
+  // closing the picker without picking anything fires cancel, never change
+  useEffect(() => {
+    const input = inputRef.current
+
+    if (input === null) return
+
+    const onCancel = () => onFileDialogCancel()
+
+    input.addEventListener('cancel', onCancel)
+
+    return () => input.removeEventListener('cancel', onCancel)
+  }, [onFileDialogCancel])
+
   const open = useCallback(() => {
     if (inputRef.current) {
       onFileDialogOpen()


### PR DESCRIPTION
## Description

The button that opens the script picker stayed disabled after closing the dialog without selecting anything.

`DropScripts` cleared `isFileDialogActive` from the input's `onChange` handler, which only fires when files are actually selected. Cancelling the picker emits `cancel` instead, so the flag stayed `true` and the button ([compilation-page.tsx:231](https://github.com/Kiyozz/papyrus-compiler-app/blob/main/src/renderer/pages/compilation/compilation-page.tsx#L231)) stayed disabled for the rest of the session.

A native `cancel` listener on the input now clears it as well.

## Notes

`onCancel` is only typed for `<dialog>` in React 19, so `tsc` rejects it as an `input` prop — hence `addEventListener` rather than a JSX handler. The `cancel` event on `<input type="file">` needs Chrome 113+, well below Electron 44.
