### PR TITLE
feat(logs): renderer log channel, report unsupported game types

### DIFF
--- a/.changeset/0019-log-unsupported-game-type.md
+++ b/.changeset/0019-log-unsupported-game-type.md
@@ -1,0 +1,5 @@
+---
+'pca': patch
+---
+
+Log an error when an unsupported game type reaches `toExecutable` instead of falling back to the Skyrim SE executable in silence, which used to make a corrupted game type look like the user had picked Skyrim.

--- a/.changeset/0020-renderer-log-channel.md
+++ b/.changeset/0020-renderer-log-channel.md
@@ -1,0 +1,5 @@
+---
+'pca': patch
+---
+
+Give the renderer a way to write to the electron-log files. It had no logger at all: its few `console` calls only ever reached the devtools and were lost once the app was packaged. Renderer entries now go through the bridge and are written by the main process under a `Renderer:<scope>` scope, so they show up in the log files users send along with a bug report.

--- a/src/common/game.ts
+++ b/src/common/game.ts
@@ -75,6 +75,12 @@ export const toExecutable = (game: GameType): Executable => {
     case GameType.sf:
       return Executable.sf
     default:
+      // falling back without a word made a corrupted game type look like the
+      // user had picked Skyrim SE, pointing every error at the wrong game
+      console.error(
+        `RuntimeError: unsupported GameType "${game}", falling back to ${Executable.se}`,
+      )
+
       return Executable.se
   }
 }

--- a/src/common/types/api.ts
+++ b/src/common/types/api.ts
@@ -3,6 +3,7 @@
  */
 
 import type { PartialDeep } from 'type-fest'
+import type { LogLevel } from '../log-level'
 import type {
   TelemetryEvent,
   TelemetryEventProperties,
@@ -28,6 +29,9 @@ export interface MainAPI {
   online(online: boolean): Promise<void>
   clipboard: {
     copy(text: string): Promise<void>
+  }
+  log: {
+    write(level: LogLevel, scope: string, message: string): Promise<void>
   }
   config: {
     update(

--- a/src/common/types/bridge.ts
+++ b/src/common/types/bridge.ts
@@ -11,6 +11,7 @@ import type { BadError } from './bad-error'
 import type { CompilationResult } from './compilation-result'
 import type { Config } from './config'
 import type { DialogType } from './dialog'
+import type { LogLevel } from '../log-level'
 import type { Disposable } from './disposable'
 import type { Platform } from './platform'
 import type { Script } from './script'
@@ -38,6 +39,10 @@ export interface Bridge {
 
   clipboard: {
     copy: (text: string) => Promise<void>
+  }
+
+  log: {
+    write: (level: LogLevel, scope: string, message: string) => Promise<void>
   }
 
   config: {

--- a/src/main/main-api.ts
+++ b/src/main/main-api.ts
@@ -32,6 +32,7 @@ export class MainApi {
   mainApi: MainAPI
 
   readonly #logger = new Logger('MainApi')
+  readonly #rendererLoggers = new Map<string, Logger>()
   readonly #mainMenu: MainMenu
   readonly #win: MainBrowserWindow
   readonly #contextMenu: ContextMenu
@@ -83,6 +84,11 @@ export class MainApi {
       },
       clipboard: {
         copy: (text) => clipboardCopyHandler.listen({ text }),
+      },
+      log: {
+        write: async (level, scope, message) => {
+          this.#rendererLogger(scope)[level](message)
+        },
       },
       config: {
         get: () => configGetHandler.listen(),
@@ -157,5 +163,20 @@ export class MainApi {
         },
       },
     }
+  }
+
+  // the renderer has no direct access to electron-log, it goes through here
+  #rendererLogger(scope: string): Logger {
+    const existing = this.#rendererLoggers.get(scope)
+
+    if (existing !== undefined) {
+      return existing
+    }
+
+    const logger = new Logger(`Renderer:${scope}`)
+
+    this.#rendererLoggers.set(scope, logger)
+
+    return logger
   }
 }

--- a/src/renderer/bridge.ts
+++ b/src/renderer/bridge.ts
@@ -86,6 +86,9 @@ export const bridge: Bridge = {
   clipboard: {
     copy: (text) => mainApi.clipboard.copy(text),
   },
+  log: {
+    write: (level, scope, message) => mainApi.log.write(level, scope, message),
+  },
   config: {
     update: (partialConfig, override) =>
       mainApi.config.update(partialConfig, override),

--- a/src/renderer/components/dialog/dialog-text-field.tsx
+++ b/src/renderer/components/dialog/dialog-text-field.tsx
@@ -5,6 +5,7 @@
 import React, { useState, type ReactNode } from 'react'
 import type { DialogType } from '#common/types/dialog.ts'
 import { bridge } from '@renderer/bridge.ts'
+import { Logger } from '@renderer/lib/logger.ts'
 import {
   FormControl,
   FormDescription,
@@ -17,6 +18,8 @@ import { Input } from '@renderer/components/ui/input.tsx'
 import { Button } from '@renderer/components/ui/button.tsx'
 import { FolderIcon, FolderOpenIcon } from 'lucide-react'
 import { useLingui } from '@lingui/react/macro'
+
+const logger = new Logger('DialogTextField')
 
 interface DialogTextFieldProps {
   name: string
@@ -76,7 +79,7 @@ function DialogTextField({
                       field.onChange(result)
                     }
                   } catch (err) {
-                    console.log(err)
+                    logger.error(err)
                   }
                 }}
                 onMouseEnter={onMouseEnter}

--- a/src/renderer/hooks/use-compilation.tsx
+++ b/src/renderer/hooks/use-compilation.tsx
@@ -10,12 +10,15 @@ import React, {
   useState,
 } from 'react'
 import { bridge } from '../bridge'
+import { Logger } from '../lib/logger'
 import { ScriptStatus } from '../enums/script-status.enum'
 import { chunk } from '../utils/chunk'
 import { scriptEquals, scriptInList } from '../utils/scripts/equals'
 import { isRunningScript } from '../utils/scripts/status'
 import { useApp } from './use-app'
 import type { ScriptRenderer } from '../types'
+
+const logger = new Logger('Compilation')
 
 interface StartOptions {
   scripts: ScriptRenderer[]
@@ -68,7 +71,7 @@ function CompilationProvider({ children }: React.PropsWithChildren) {
 
   const start = useCallback(
     async ({ scripts }: StartOptions) => {
-      console.log('Starting compilation for', scripts)
+      logger.debug('starting compilation for', scripts.length, 'scripts')
       setCompilationLogs((logs) => {
         return logs.filter(([s]) => {
           return !scriptInList(scripts)(s)

--- a/src/renderer/lib/logger.ts
+++ b/src/renderer/lib/logger.ts
@@ -1,0 +1,64 @@
+/*
+ * 2026 Kiyozz.
+ */
+
+import { bridge } from '@renderer/bridge.ts'
+import { LogLevel } from '#common/log-level.ts'
+
+function format(param: unknown): string {
+  if (typeof param === 'string') return param
+
+  if (param instanceof Error) {
+    return param.stack ?? `${param.name}: ${param.message}`
+  }
+
+  if (typeof param === 'object' && param !== null) {
+    try {
+      return JSON.stringify(param)
+    } catch {
+      return String(param)
+    }
+  }
+
+  return String(param)
+}
+
+/**
+ * The renderer cannot reach electron-log directly, so entries are forwarded to
+ * the main process, which writes them to the log files. Also kept in the
+ * devtools console, where they are useful while developing.
+ */
+class Logger {
+  readonly #scope: string
+
+  constructor(scope: string) {
+    this.#scope = scope
+  }
+
+  debug(...params: unknown[]): void {
+    this.#write(LogLevel.debug, params)
+  }
+
+  info(...params: unknown[]): void {
+    this.#write(LogLevel.info, params)
+  }
+
+  warn(...params: unknown[]): void {
+    this.#write(LogLevel.warn, params)
+  }
+
+  error(...params: unknown[]): void {
+    this.#write(LogLevel.error, params)
+  }
+
+  #write(level: LogLevel, params: unknown[]): void {
+    console[level](`(${this.#scope})`, ...params)
+
+    // never let a broken channel take down what was being logged
+    void bridge.log
+      .write(level, this.#scope, params.map(format).join(' '))
+      .catch(() => {})
+  }
+}
+
+export { Logger }

--- a/src/renderer/locales/en/messages.po
+++ b/src/renderer/locales/en/messages.po
@@ -261,7 +261,7 @@ msgstr "Reduce if you experience latency when starting the compilation"
 msgid "Retirer"
 msgstr "Remove"
 
-#: src/renderer/components/dialog/dialog-text-field.tsx:55
+#: src/renderer/components/dialog/dialog-text-field.tsx:58
 msgid "Sélectionner un dossier"
 msgstr "Select a folder"
 

--- a/src/renderer/locales/en/messages.po
+++ b/src/renderer/locales/en/messages.po
@@ -113,7 +113,7 @@ msgid "Depuis la version 5.9.0, l'intégration MO2 a été supprimée. Configure
 msgstr "Since version 5.9.0, the MO2 integration has been removed. Configure PCA to be launched via MO2 instead."
 
 #: src/renderer/components/app-sidebar.tsx:57
-#: src/renderer/pages/settings/settings-page.tsx:276
+#: src/renderer/pages/settings/settings-page.tsx:273
 msgid "Documentation"
 msgstr "Documentation"
 
@@ -234,7 +234,7 @@ msgid "Nouvelle version disponible : {latestVersion}"
 msgstr "New version available: {latestVersion}"
 
 #: src/renderer/components/app-sidebar.tsx:44
-#: src/renderer/pages/settings/settings-page.tsx:261
+#: src/renderer/pages/settings/settings-page.tsx:258
 msgid "Paramètres"
 msgstr "Settings"
 
@@ -248,7 +248,7 @@ msgstr "More details"
 msgid "Préférences"
 msgstr "Preferences"
 
-#: src/renderer/pages/settings/settings-page.tsx:286
+#: src/renderer/pages/settings/settings-page.tsx:283
 msgid "Rafraîchir"
 msgstr "Refresh"
 

--- a/src/renderer/locales/fr/messages.po
+++ b/src/renderer/locales/fr/messages.po
@@ -113,7 +113,7 @@ msgid "Depuis la version 5.9.0, l'intégration MO2 a été supprimée. Configure
 msgstr "Depuis la version 5.9.0, l'intégration MO2 a été supprimée. Configurez PCA pour être lancé via MO2 à la place."
 
 #: src/renderer/components/app-sidebar.tsx:57
-#: src/renderer/pages/settings/settings-page.tsx:276
+#: src/renderer/pages/settings/settings-page.tsx:273
 msgid "Documentation"
 msgstr "Documentation"
 
@@ -234,7 +234,7 @@ msgid "Nouvelle version disponible : {latestVersion}"
 msgstr "Nouvelle version disponible : {latestVersion}"
 
 #: src/renderer/components/app-sidebar.tsx:44
-#: src/renderer/pages/settings/settings-page.tsx:261
+#: src/renderer/pages/settings/settings-page.tsx:258
 msgid "Paramètres"
 msgstr "Paramètres"
 
@@ -248,7 +248,7 @@ msgstr "Plus de détails"
 msgid "Préférences"
 msgstr "Préférences"
 
-#: src/renderer/pages/settings/settings-page.tsx:286
+#: src/renderer/pages/settings/settings-page.tsx:283
 msgid "Rafraîchir"
 msgstr "Rafraîchir"
 

--- a/src/renderer/locales/fr/messages.po
+++ b/src/renderer/locales/fr/messages.po
@@ -261,7 +261,7 @@ msgstr "Réduisez si vous rencontrez des blocages quand vous lancez la compilati
 msgid "Retirer"
 msgstr "Retirer"
 
-#: src/renderer/components/dialog/dialog-text-field.tsx:55
+#: src/renderer/components/dialog/dialog-text-field.tsx:58
 msgid "Sélectionner un dossier"
 msgstr "Sélectionner un dossier"
 


### PR DESCRIPTION
## Description

Follow-up to #166, where a corrupted game type silently made the app ask for `SkyrimSE.exe` and nothing in the logs pointed at the real cause.

**`toExecutable` no longer falls back in silence.** Its `default` branch returned `Executable.se` for any unknown game type, so a bad value looked exactly like the user having picked Skyrim SE. It now reports the offending value before falling back. No `throw`: a corrupted config should not take the window down.

It uses `console.error` rather than the project `Logger`, because `common/game.ts` is imported by the renderer — pulling in `electron-log` and `electron-util/main` there crashes the renderer at startup (verified).

**The renderer can now write to the log files.** It had no logger at all: three `console` calls across the whole of `src/renderer`, reaching the devtools and nothing else, lost as soon as the app is packaged. A `log.write(level, scope, message)` channel on the bridge is written by the main process through `electron-log`, under a `Renderer:<scope>` scope so the origin is obvious in the file. Existing log level settings apply unchanged, since filtering stays on the electron-log side.

`renderer/lib/logger.ts` mirrors the main `Logger` API (`debug`/`info`/`warn`/`error`, variadic params). It keeps writing to the devtools console as well, serialises objects before sending them over kkrpc, and renders `Error` through its stack. The bridge call is fire-and-forget with a swallowed rejection — a broken channel must not take down the code that was merely trying to trace something.

`use-compilation.tsx` and `dialog-text-field.tsx` now use it.

## Notes

Two `console` calls are deliberately left as they are:

- `renderer/bridge.ts` — the logger imports the bridge, so logging from there would be an import cycle, and `import/no-cycle` is an error in the oxlint config.
- `common/game.ts` — shared between main and renderer, it can import neither logger. This is the one spot the new channel does not cover.

The `.po` churn is `lingui extract` refreshing source line references, shifted by the `toFlag` change in #166 and by the edits here.
