### PR TITLE
feat(telemetry): send App.FirstLoaded with versions

### DIFF
--- a/.changeset/0021-telemetry-first-loaded.md
+++ b/.changeset/0021-telemetry-first-loaded.md
@@ -1,0 +1,5 @@
+---
+'pca': patch
+---
+
+Send the `App.FirstLoaded` telemetry event again on the very first launch, with the app version and the public version.

--- a/.changeset/0022-telemetry-esm-fetch.md
+++ b/.changeset/0022-telemetry-esm-fetch.md
@@ -1,0 +1,5 @@
+---
+'pca': patch
+---
+
+Fix telemetry never being sent: `electron-fetch` only ships CommonJS, so its default import resolved to the module object instead of the fetch function in the ESM main process. Replaced by Electron `net.fetch` and the dependency is dropped.

--- a/package.json
+++ b/package.json
@@ -69,7 +69,6 @@
     "electron-builder": "~26.15.7",
     "electron-context-menu": "^4.1.2",
     "electron-default-menu": "~1.0.2",
-    "electron-fetch": "^1.9.1",
     "electron-log": "~5.4.4",
     "electron-store": "~11.0.2",
     "electron-tsdown": "^12.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -119,9 +119,6 @@ importers:
       electron-default-menu:
         specifier: ~1.0.2
         version: 1.0.2
-      electron-fetch:
-        specifier: ^1.9.1
-        version: 1.9.1
       electron-log:
         specifier: ~5.4.4
         version: 5.4.4
@@ -3553,10 +3550,6 @@ packages:
   electron-dl@4.0.0:
     resolution: {integrity: sha512-USiB9816d2JzKv0LiSbreRfTg5lDk3lWh0vlx/gugCO92ZIJkHVH0UM18EHvKeadErP6Xn4yiTphWzYfbA2Ong==}
     engines: {node: '>=18'}
-
-  electron-fetch@1.9.1:
-    resolution: {integrity: sha512-M9qw6oUILGVrcENMSRRefE1MbHPIz0h79EKIeJWK9v563aT9Qkh8aEHPO1H5vi970wPirNY+jO9OpFoLiMsMGA==}
-    engines: {node: '>=6'}
 
   electron-is-dev@3.0.1:
     resolution: {integrity: sha512-8TjjAh8Ec51hUi3o4TaU0mD3GMTOESi866oRNavj9A3IQJ7pmv+MJVmdZBFGw4GFT36X7bkqnuDNYvkQgvyI8Q==}
@@ -9783,10 +9776,6 @@ snapshots:
       pupa: 3.3.0
       unused-filename: 4.0.1
 
-  electron-fetch@1.9.1:
-    dependencies:
-      encoding: 0.1.13
-
   electron-is-dev@3.0.1: {}
 
   electron-log@5.4.4: {}
@@ -9876,6 +9865,7 @@ snapshots:
   encoding@0.1.13:
     dependencies:
       iconv-lite: 0.6.3
+    optional: true
 
   end-of-stream@1.4.5:
     dependencies:
@@ -10436,6 +10426,7 @@ snapshots:
   iconv-lite@0.6.3:
     dependencies:
       safer-buffer: 2.1.2
+    optional: true
 
   iconv-lite@0.7.3:
     dependencies:

--- a/src/common/telemetry-event.ts
+++ b/src/common/telemetry-event.ts
@@ -38,7 +38,7 @@ export enum TelemetryEvent {
 }
 
 export interface TelemetryEventProperties {
-  [TelemetryEvent.appFirstLoaded]: Record<string, never>
+  [TelemetryEvent.appFirstLoaded]: Record<'version' | 'publicVersion', string>
   [TelemetryEvent.appLoaded]: Record<'version' | 'publicVersion', string>
   [TelemetryEvent.compilationDropScripts]: { scripts: number }
   [TelemetryEvent.compilationGroupLoaded]: { groups: number }

--- a/src/main/container.ts
+++ b/src/main/container.ts
@@ -20,6 +20,8 @@ import { RecentFilesStore } from '#main/store/recent-files/store.ts'
 import Emittery from 'emittery'
 import { PapyrusCompilerService } from '#main/compilation/compile.ts'
 import { Compiler } from '#main/compilation/compiler.ts'
+import { Telemetry } from '#main/telemetry/telemetry.ts'
+import { Env } from '#main/env.ts'
 
 const emitter = new Emittery()
 
@@ -60,6 +62,13 @@ container.swap(Compiler, (resolver) => {
   return resolver.make(PapyrusCompilerService)
 })
 container.singleton(EventEmitter, () => new EventEmitter())
+// one instance only: the queue and the active/online state are shared
+container.singleton(Telemetry, async (resolver) => {
+  const settingsStore = await resolver.make(SettingsStore)
+  const env = await resolver.make(Env)
+
+  return new Telemetry(settingsStore, env)
+})
 container.singleton(RpcChannel, async (resolver) => {
   const win = await resolver.make(MainBrowserWindow)
   const transport = electronIpcTransport({

--- a/src/main/initialize.ts
+++ b/src/main/initialize.ts
@@ -5,9 +5,13 @@
 import { Logger } from './logger'
 import { ensureFiles, move, writeFile } from './path/path'
 import { WindowStore } from './store/window/store'
+import { publicVersion } from '#common/version.ts'
+import { TelemetryEvent } from '#common/telemetry-event.ts'
 import { MainBrowserWindow } from '#main/main-browser-window.ts'
 import { RpcChannel } from '#main/rpc-channel.ts'
 import { SettingsStore } from '#main/store/settings/store.ts'
+import { Telemetry } from '#main/telemetry/telemetry.ts'
+import { GetVersionHandler } from '#event-handlers/get-version.handler.ts'
 import { inject } from '#main/inject.ts'
 
 const logger = new Logger('Initialize')
@@ -18,21 +22,27 @@ export class Initializer {
   #rpc: RpcChannel
   #settingsStore: SettingsStore
   #windowStore: WindowStore
+  #telemetry: Telemetry
 
   constructor(
     win: MainBrowserWindow,
     rpc: RpcChannel,
     settingsStore: SettingsStore,
     windowStore: WindowStore,
+    telemetry: Telemetry,
   ) {
     this.#win = win
     this.#rpc = rpc
     this.#settingsStore = settingsStore
     this.#windowStore = windowStore
+    this.#telemetry = telemetry
   }
 
   async initialize() {
     await this.#backupLogFile()
+
+    // do not block the initialization on a network call
+    void this.#sendFirstLoaded()
 
     const rendererApi = this.#rpc.getAPI()
 
@@ -64,6 +74,25 @@ export class Initializer {
 
       this.#windowStore.set({ x, y })
     })
+  }
+
+  async #sendFirstLoaded() {
+    if (!this.#settingsStore.firstLaunch) {
+      return
+    }
+
+    logger.info('first launch of the app')
+
+    const version = await new GetVersionHandler().listen()
+
+    try {
+      await this.#telemetry.event({
+        name: TelemetryEvent.appFirstLoaded,
+        properties: { version, publicVersion },
+      })
+    } catch {
+      logger.debug("can't send the first launch telemetry event")
+    }
   }
 
   async #backupLogFile() {

--- a/src/main/store/settings/store.ts
+++ b/src/main/store/settings/store.ts
@@ -40,6 +40,9 @@ const json = JSON.parse(fs.readFileSync(jsonPath).toString()) as {
   version: string
 }
 
+// electron-store default file name, the settings store does not override it
+const SETTINGS_STORE_NAME = 'config'
+
 const defaultSettingsStoreConfig: Config = {
   game: {
     path: '',
@@ -71,6 +74,16 @@ const defaultSettingsStoreConfig: Config = {
 @inject()
 class SettingsStore extends Store<Config> {
   #logger = new Logger('SettingsStore')
+  #firstLaunch = false
+
+  // true when no settings file existed when the app started
+  get firstLaunch(): boolean {
+    return this.#firstLaunch
+  }
+
+  set firstLaunch(firstLaunch: boolean) {
+    this.#firstLaunch = firstLaunch
+  }
 
   resetSettings() {
     this.store = { ...defaultSettingsStoreConfig }
@@ -266,6 +279,14 @@ class SettingsStore extends Store<Config> {
 }
 
 function createSettingsStore() {
+  // the settings file is written on the very first run: no file means the app
+  // has never been launched on this machine
+  const settingsPath = join(
+    app.getPath('userData'),
+    `${SETTINGS_STORE_NAME}.json`,
+  )
+  const firstLaunch = !fs.existsSync(settingsPath)
+
   const store = new SettingsStore({
     defaults: defaultSettingsStoreConfig,
     projectVersion: json.version,
@@ -279,6 +300,10 @@ function createSettingsStore() {
       '5.9.0': migrate590,
     },
   } as never)
+
+  // store.path is only known once the file has been written: comparing it here
+  // guards against a wrong first launch if electron-store renames the file
+  store.firstLaunch = firstLaunch && store.path === settingsPath
 
   store.check(cliArgs)
 

--- a/src/main/telemetry/telemetry.ts
+++ b/src/main/telemetry/telemetry.ts
@@ -3,8 +3,7 @@
  */
 
 import is from '@sindresorhus/is'
-import fetch, { Headers } from 'electron-fetch'
-import type { Response } from 'electron-fetch'
+import { net } from 'electron'
 import Queue from 'queue'
 import { TelemetryEvent } from '#common/telemetry-event.ts'
 import type { TelemetryEventProperties } from '#common/telemetry-event.ts'
@@ -99,7 +98,7 @@ export class Telemetry {
       this.#telemetryQueue.push(async () => {
         try {
           this.#logger.debug('send telemetry data', payloadWithoutAppKey)
-          const response = await fetch(`${this.#api}${endpoint}`, {
+          const response = await net.fetch(`${this.#api}${endpoint}`, {
             method,
             body: JSON.stringify(payload),
             headers: Telemetry._getHeaders(),


### PR DESCRIPTION
## Issues

Closes #156

## Description

`App.FirstLoaded` stopped being sent when the tutorial was removed, and carried no properties. It is now sent from the main process on the very first launch, with `version` (app version) and `publicVersion` (calendar release), mirroring `App.Loaded`.

First launch is detected from the absence of `<userData>/config.json` at startup. A store migration cannot be used here: the defaults write `__internal__.migrations.version` at the current version, so migrations also run on a fresh install and cannot tell the two apart.

## Notes

- While testing end to end, telemetry turned out to be broken for every event: `electron-fetch` only ships CommonJS (`main: lib/index.js`, no `exports` field), so in the ESM main process the default import resolved to the module object and every send failed with `fetch is not a function`, disabling telemetry for the session. Replaced by Electron `net.fetch` (available since Electron 22) and the dependency is dropped — `Headers` and `Response` are the globals now.
- `Telemetry` is registered as a container singleton: without it the initializer would have received a second instance, with its own queue and a diverging `online`/`active` state from the one `MainApi` uses.
- Verified against a local capture server, on a fresh `userData`: `POST /events {"type":"App.FirstLoaded","properties":{"version":"5.8.0","publicVersion":"2025.1"}}`. A second launch on the same `userData` sends nothing.
