### PR TITLE
fix(compilation): compile the picked script, not a namesake

### DIFF
--- a/.changeset/0023-script-resolution-import-order.md
+++ b/.changeset/0023-script-resolution-import-order.md
@@ -1,0 +1,5 @@
+---
+'pca': patch
+---
+
+Compile the script that was picked, not a namesake found in the game sources. The compiler resolves a script name against the current working directory (always first) then the imports in order, keeping the first match: the folder of the script is now both the working directory and the first import. Fixes wrong script compiled when several import folders hold the same name, typically under MO2 where Data merges every mod.

--- a/src/main/compilation/compile.ts
+++ b/src/main/compilation/compile.ts
@@ -62,10 +62,16 @@ class PapyrusCompilerService implements Compiler {
       outputPath.trim() === ''
         ? path.join(gamePath, 'Data/Scripts')
         : outputPath
+    // the compiler is given a script name, never a path: it resolves that name
+    // against the cwd (always implied first) then the imports, in order, and
+    // keeps the first match. importDir must therefore stay first everywhere,
+    // otherwise a script of the same name sitting in the game sources - the
+    // rule under MO2, where Data is the merge of every mod - is compiled
+    // instead of the one the user picked.
     const runner: Runner = {
       exe: compilerPath,
-      imports: [gameSourceAbsolute, importDir],
-      cwd: gamePath,
+      imports: [importDir, gameSourceAbsolute],
+      cwd: importDir,
       output: resolvedOutput,
     }
 


### PR DESCRIPTION
## Issues

#155

## Description

The compiler was handed a script *name*, never a path, and resolved it against the current working directory (always implied first) then the imports, in order, keeping the first match. So the file actually compiled was not the one the user picked, but the first namesake in that search order.

Two things made that go wrong:

- `cwd` was the game folder, which had nothing to do with the script being compiled
- the initial import list was `[gameSource, importDir]`, and the LE/SE/VR branch only reordered it when `Data/<otherSource>` existed - so on Skyrim LE (no `Data/Source/Scripts`) and on SE installs without `Data/Scripts/Source`, the game sources were searched before the script's own folder

The fix makes the script folder both the working directory and the first import.

This is why it only showed up under MO2: the VFS makes `Data/Scripts/Source` the merge of every mod's sources, so a namesake collision with the picked script's real folder is close to guaranteed. Outside MO2 the Data folder is not merged and nothing collides.

## Notes

Behaviour verified against three real compilers - Skyrim SE (Creation Kit), Fallout 4 2.8.0.4 and Starfield 4.7.0.5 - with two folders each holding a different `Foo.psc`:

| Test | SE | FO4 | SF |
|---|---|---|---|
| `-i="A;B"` | A | A | A |
| `-i="B;A"` | B | B | B |
| cwd=A, `-i="B"` | A | A | A |
| cwd=A, `-ignorecwd`, `-i="B"` | flag absent | B | B |
| target = absolute path to B, cwd=A, `-i="A"` | **A** | B | B |
| target = absolute path, namespaced script | - | fails | fails |

Two approaches were ruled out by those results:

- passing the absolute path of the psc: the Skyrim compiler truncates the target to its base name (`Compiling "Foo"...`, then `unable to locate script Foo` when no import holds it), so the path is only ever used in error messages
- `-ignorecwd`: does not exist on the Skyrim compiler

Setting `cwd` to the script folder is the only lever that works on all three, and it needs no compiler flag.

Manually tested on Skyrim SE (fails before, succeeds after, pex contains the mod's version) and on Fallout 4 with a namespaced script (unchanged before and after, pex still written to its namespace subfolder).

Unrelated bug spotted while testing, not addressed here: the Succès/Échec badge in the compilation logs dialog shows the status of the *previous* run, because `use-compilation.tsx` stores the log entry with the `ScriptRenderer` snapshot captured before compiling.
