### PR TITLE
fix(logs): badge reflects the displayed run result

### DIFF
--- a/.changeset/0024-compilation-log-status.md
+++ b/.changeset/0024-compilation-log-status.md
@@ -1,0 +1,5 @@
+---
+'pca': patch
+---
+
+Show the real result of a run on its compilation log entry. The Success/Failure badge was derived from the script status captured before compilation started, so it showed the previous run's outcome (and "Failure" on a first run). Each log entry now carries the compiler result it came from.

--- a/src/renderer/components/dialog/dialog-compilation-logs.tsx
+++ b/src/renderer/components/dialog/dialog-compilation-logs.tsx
@@ -17,10 +17,6 @@ import { useApp } from '@renderer/hooks/use-app.tsx'
 import { useCompilation } from '@renderer/hooks/use-compilation.tsx'
 import { useTelemetry } from '@renderer/hooks/use-telemetry.tsx'
 import { logsState } from '@renderer/lib/logs.ts'
-import {
-  isFailedScript,
-  isSuccessScript,
-} from '@renderer/utils/scripts/status.ts'
 import { ClipboardIcon, FileXIcon, Trash2Icon } from 'lucide-react'
 import { type PropsWithChildren, useState } from 'react'
 import { Trans, useLingui } from '@lingui/react/macro'
@@ -40,9 +36,7 @@ export function DialogCompilationLogs({ children }: PropsWithChildren) {
   const [showErrorOnly, setShowErrorOnly] = useState(false)
   const [showFullPath, setShowFullPath] = useState(false)
 
-  const logs = showErrorOnly
-    ? rawLogs.filter(([script]) => isFailedScript(script))
-    : rawLogs
+  const logs = showErrorOnly ? rawLogs.filter((log) => !log.success) : rawLogs
 
   const onClickClearLogs = () => {
     clearCompilationLogs()
@@ -112,11 +106,11 @@ export function DialogCompilationLogs({ children }: PropsWithChildren) {
                     <Trans>Aucune erreur !</Trans>
                   </li>
                 )}
-                {logs.map(([script, log]) => {
+                {logs.map(({ script, output, success }) => {
                   const onClickCopy = () => {
                     send(TelemetryEvent.compilationLogsCopy, {})
                     copyToClipboard(
-                      `${script.name}-${script.path}\n\n${log.trim()}\n`,
+                      `${script.name}-${script.path}\n\n${output.trim()}\n`,
                     )
                     toast.info(t`Copier avec succès`, {
                       duration: Infinity,
@@ -126,9 +120,6 @@ export function DialogCompilationLogs({ children }: PropsWithChildren) {
                   const onClickDelete = () => {
                     clearCompilationLogs(script)
                   }
-
-                  const isSuccessful = isSuccessScript(script)
-                  const isError = isFailedScript(script)
 
                   return (
                     <li
@@ -149,12 +140,12 @@ export function DialogCompilationLogs({ children }: PropsWithChildren) {
                             ) : (
                               <span>{script.name}</span>
                             )}
-                            {isSuccessful && (
+                            {success && (
                               <Badge variant="success">
                                 <Trans>Succès</Trans>
                               </Badge>
                             )}
-                            {isError && (
+                            {!success && (
                               <Badge variant="destructive">
                                 <Trans>Échec</Trans>
                               </Badge>
@@ -179,7 +170,7 @@ export function DialogCompilationLogs({ children }: PropsWithChildren) {
                         id={`${script.id}-logs`}
                         role="log"
                       >
-                        {log.split('\n').map((outputLine, i) => (
+                        {output.split('\n').map((outputLine, i) => (
                           <span
                             className="block select-text wrap-break-word text-balance font-mono text-xs leading-6"
                             key={i}

--- a/src/renderer/hooks/use-compilation.tsx
+++ b/src/renderer/hooks/use-compilation.tsx
@@ -16,7 +16,7 @@ import { chunk } from '../utils/chunk'
 import { scriptEquals, scriptInList } from '../utils/scripts/equals'
 import { isRunningScript } from '../utils/scripts/status'
 import { useApp } from './use-app'
-import type { ScriptRenderer } from '../types'
+import type { CompilationLog, ScriptRenderer } from '../types'
 
 const logger = new Logger('Compilation')
 
@@ -29,7 +29,7 @@ interface CompilationContext {
   isRunning: boolean
   scripts: ScriptRenderer[]
   concurrentScripts: number
-  logs: [ScriptRenderer, string][]
+  logs: CompilationLog[]
   setScripts: (fn: (scripts: ScriptRenderer[]) => ScriptRenderer[]) => void
   clearCompilationLogs: (script?: ScriptRenderer) => void
 }
@@ -40,9 +40,7 @@ function CompilationProvider({ children }: React.PropsWithChildren) {
   const [compilationScripts, setCompilationScripts] = useState<
     ScriptRenderer[]
   >([])
-  const [compilationLogs, setCompilationLogs] = useState<
-    [ScriptRenderer, string][]
-  >([])
+  const [compilationLogs, setCompilationLogs] = useState<CompilationLog[]>([])
   const { config } = useApp()
   const concurrentScripts = useMemo(
     () =>
@@ -60,8 +58,8 @@ function CompilationProvider({ children }: React.PropsWithChildren) {
   const clearCompilationLogs = useCallback((script?: ScriptRenderer) => {
     if (script) {
       setCompilationLogs((logs) => {
-        return logs.filter(([s]) => {
-          return !scriptEquals(script)(s)
+        return logs.filter((log) => {
+          return !scriptEquals(script)(log.script)
         })
       })
     } else {
@@ -73,8 +71,8 @@ function CompilationProvider({ children }: React.PropsWithChildren) {
     async ({ scripts }: StartOptions) => {
       logger.debug('starting compilation for', scripts.length, 'scripts')
       setCompilationLogs((logs) => {
-        return logs.filter(([s]) => {
-          return !scriptInList(scripts)(s)
+        return logs.filter((log) => {
+          return !scriptInList(scripts)(log.script)
         })
       })
 
@@ -107,7 +105,10 @@ function CompilationProvider({ children }: React.PropsWithChildren) {
               )
 
               setCompilationLogs((cl) => {
-                return [[s, result.output], ...cl]
+                return [
+                  { script: s, output: result.output, success: result.success },
+                  ...cl,
+                ]
               })
             })
           }),

--- a/src/renderer/lib/logs.ts
+++ b/src/renderer/lib/logs.ts
@@ -2,18 +2,13 @@
  * 2026 Kiyozz.
  */
 
-import type { ScriptRenderer } from '@renderer/types/index.ts'
-import {
-  isFailedScript,
-  isSuccessScript,
-} from '@renderer/utils/scripts/status.ts'
+import type { CompilationLog } from '@renderer/types/index.ts'
 
-export function logsState(logs: [ScriptRenderer, string][]) {
+export function logsState(logs: CompilationLog[]) {
   const hasNoLogs = logs.length === 0
   const hasLogs = logs.length > 0
-  const hasErrorsInLogs = logs.some(([log]) => isFailedScript(log))
-  const isAllScriptsSuccessInLogs =
-    hasLogs && logs.every(([log]) => isSuccessScript(log))
+  const hasErrorsInLogs = logs.some((log) => !log.success)
+  const isAllScriptsSuccessInLogs = hasLogs && logs.every((log) => log.success)
 
   return {
     hasNoLogs,

--- a/src/renderer/types/compilation-log.ts
+++ b/src/renderer/types/compilation-log.ts
@@ -1,0 +1,11 @@
+/*
+ * 2026 Kiyozz.
+ */
+
+import type { ScriptRenderer } from './script-renderer'
+
+export type CompilationLog = {
+  script: ScriptRenderer
+  output: string
+  success: boolean
+}

--- a/src/renderer/types/index.ts
+++ b/src/renderer/types/index.ts
@@ -5,3 +5,4 @@
 export * from './group'
 export * from './script-renderer'
 export * from './github-release'
+export * from './compilation-log'

--- a/src/renderer/utils/scripts/status.ts
+++ b/src/renderer/utils/scripts/status.ts
@@ -8,11 +8,3 @@ import type { ScriptRenderer } from '../../types'
 export function isRunningScript(script: ScriptRenderer) {
   return script.status === ScriptStatus.running
 }
-
-export function isSuccessScript(script: ScriptRenderer) {
-  return script.status === ScriptStatus.success
-}
-
-export function isFailedScript(script: ScriptRenderer) {
-  return script.status === ScriptStatus.failed
-}


### PR DESCRIPTION
## Description

The Success/Failure badge in the compilation logs dialog showed the status of the *previous* run, not the run whose log is displayed.

Log entries were pushed as `[[s, result.output], ...cl]` where `s` is the `ScriptRenderer` captured **before** compilation, so its `status` was stale. The dialog then derived the badge from `isSuccessScript(script)` on that frozen snapshot. On a first run (`idle` status) the badge fell through to the default branch and wrongly showed "Failure".

Log entries now carry the actual compiler result:

- new `CompilationLog` type (`{ script, output, success }`), replacing the `[ScriptRenderer, string]` tuple
- `use-compilation` stores `result.success` alongside the output
- badge, "errors only" filter, `hasErrorsInLogs` and `isAllScriptsSuccessInLogs` all derive from `log.success`
- `isSuccessScript` / `isFailedScript` had no remaining callers and are removed

## Notes

`src/main/compilation/compile.ts` is untouched (separate fix in progress for #155).