### PR TITLE
feat(compilation): button to open the folder of the compiled script

### DIFF
--- a/.changeset/0025-open-compiled-folder.md
+++ b/.changeset/0025-open-compiled-folder.md
@@ -1,0 +1,5 @@
+---
+'pca': minor
+---
+
+Button to open the folder the pex was written to, in the script list and in the compilation logs. Namespaces (Fallout 4, Starfield) included.

--- a/src/common/telemetry-event.ts
+++ b/src/common/telemetry-event.ts
@@ -11,6 +11,7 @@ export enum TelemetryEvent {
   compilationGroupLoaded = 'Compilation.GroupLoaded',
   compilationListEmpty = 'Compilation.ListEmpty',
   compilationLogsCopy = 'Compilation.LogsCopy',
+  compilationOpenCompiledFolder = 'Compilation.OpenCompiledFolder',
   compilationPlay = 'Compilation.Play',
   compilationSinglePlay = 'Compilation.SinglePlay',
   compilationRemoveScript = 'Compilation.RemoveScript',
@@ -44,6 +45,9 @@ export interface TelemetryEventProperties {
   [TelemetryEvent.compilationGroupLoaded]: { groups: number }
   [TelemetryEvent.compilationListEmpty]: { scripts: number }
   [TelemetryEvent.compilationLogsCopy]: Record<string, never>
+  [TelemetryEvent.compilationOpenCompiledFolder]: {
+    from: 'logs' | 'script-line'
+  }
   [TelemetryEvent.compilationPlay]: {
     scripts: number
     concurrentScripts: number

--- a/src/common/types/api.ts
+++ b/src/common/types/api.ts
@@ -63,6 +63,8 @@ export interface MainAPI {
   }
   shell: {
     openExternal(href: string): Promise<void>
+    /** opens the folder of `target`, `target` highlighted when it still exists */
+    showInFolder(target: string): Promise<boolean>
   }
   titlebar: {
     openMenu(args: { x: number; y: number }): Promise<void>

--- a/src/common/types/bridge.ts
+++ b/src/common/types/bridge.ts
@@ -70,6 +70,7 @@ export interface Bridge {
 
   shell: {
     openExternal: (href: string) => Promise<void>
+    showInFolder: (target: string) => Promise<boolean>
   }
 
   recentFiles: {

--- a/src/common/types/compilation-result.ts
+++ b/src/common/types/compilation-result.ts
@@ -6,4 +6,6 @@ export interface CompilationResult {
   script: string
   output: string
   success: boolean
+  /** absolute path of the compiled pex, undefined when the compilation failed */
+  pexPath?: string
 }

--- a/src/main/compilation/compile.ts
+++ b/src/main/compilation/compile.ts
@@ -62,6 +62,12 @@ class PapyrusCompilerService implements Compiler {
       outputPath.trim() === ''
         ? path.join(gamePath, 'Data/Scripts')
         : outputPath
+    // the compiler mirrors the namespace as folders under the output:
+    // `Mod:Sub:Script` is written to `<output>/Mod/Sub/Script.pex`
+    const pexPath = `${path.join(
+      resolvedOutput,
+      ...scriptName.replace(/\.psc$/i, '').split(':'),
+    )}.pex`
     // the compiler is given a script name, never a path: it resolves that name
     // against the cwd (always implied first) then the imports, in order, and
     // keeps the first match. importDir must therefore stay first everywhere,
@@ -150,7 +156,7 @@ class PapyrusCompilerService implements Compiler {
 
       this.#checkCommandResult(scriptName, result)
 
-      return { output: result.stdout.trim(), name: scriptName }
+      return { output: result.stdout.trim(), name: scriptName, pexPath }
     } catch (err) {
       if (err instanceof CompilationException) {
         throw err

--- a/src/main/compilation/compiler.ts
+++ b/src/main/compilation/compiler.ts
@@ -7,6 +7,8 @@ export interface CompileResult {
   output: string
   /** name given to the compiler, namespaced when the script declares one */
   name: string
+  /** absolute path of the pex the compiler writes */
+  pexPath: string
 }
 
 export abstract class Compiler {

--- a/src/main/event-handlers/script-compile.event.ts
+++ b/src/main/event-handlers/script-compile.event.ts
@@ -64,12 +64,13 @@ export class ScriptCompileEvent {
     const scriptName = basename(scriptPath)
 
     try {
-      const { output, name } = await this.#compiler.compile(scriptPath)
+      const { output, name, pexPath } = await this.#compiler.compile(scriptPath)
 
       return {
         success: true,
         output: ScriptCompileEvent._cleanSuccessLog(name, output),
         script: scriptName,
+        pexPath,
       }
     } catch (e) {
       const errorMessage: string = fromError(e).message

--- a/src/main/main-api.ts
+++ b/src/main/main-api.ts
@@ -22,6 +22,7 @@ import { RecentFilesRemoveHandler } from '#event-handlers/recent-files-remove.ha
 import { shell } from 'electron'
 import { MainBrowserWindow } from '#main/main-browser-window.ts'
 import { Logger } from '#main/logger.ts'
+import * as path from '#main/path/path.ts'
 import { Platform } from '#main/platform.ts'
 import { Telemetry } from '#main/telemetry/telemetry.ts'
 import { MainMenu } from '#main/main-menu.ts'
@@ -128,6 +129,33 @@ export class MainApi {
       },
       shell: {
         openExternal: (href) => shell.openExternal(href),
+        showInFolder: async (target) => {
+          if (path.exists(target)) {
+            shell.showItemInFolder(target)
+
+            return true
+          }
+
+          // the file can have been moved or removed since it was written, its
+          // folder is still what the user asked for
+          const folder = path.parentDir(target)
+
+          if (!path.exists(folder)) {
+            this.#logger.warn('the folder to show does not exist', folder)
+
+            return false
+          }
+
+          const error = await shell.openPath(folder)
+
+          if (error !== '') {
+            this.#logger.error('cannot open the folder', folder, error)
+
+            return false
+          }
+
+          return true
+        },
       },
       titlebar: {
         openMenu: async (args) => {

--- a/src/renderer/bridge.ts
+++ b/src/renderer/bridge.ts
@@ -112,6 +112,7 @@ export const bridge: Bridge = {
   },
   shell: {
     openExternal: (href) => mainApi.shell.openExternal(href),
+    showInFolder: (target) => mainApi.shell.showInFolder(target),
   },
   recentFiles: {
     get: () => mainApi.recentFiles.get(),

--- a/src/renderer/components/dialog/dialog-compilation-logs.tsx
+++ b/src/renderer/components/dialog/dialog-compilation-logs.tsx
@@ -17,14 +17,25 @@ import { useApp } from '@renderer/hooks/use-app.tsx'
 import { useCompilation } from '@renderer/hooks/use-compilation.tsx'
 import { useTelemetry } from '@renderer/hooks/use-telemetry.tsx'
 import { logsState } from '@renderer/lib/logs.ts'
-import { ClipboardIcon, FileXIcon, Trash2Icon } from 'lucide-react'
+import {
+  ClipboardIcon,
+  FileXIcon,
+  FolderOpenIcon,
+  Trash2Icon,
+} from 'lucide-react'
 import { type PropsWithChildren, useState } from 'react'
 import { Trans, useLingui } from '@lingui/react/macro'
 import { toast } from 'sonner'
 import { TelemetryEvent } from '#common/telemetry-event.ts'
 import { Switch } from '@renderer/components/ui/switch.tsx'
 import { Label } from '@renderer/components/ui/label.tsx'
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from '@renderer/components/ui/tooltip.tsx'
 import { Badge } from '../ui/badge.tsx'
+import { useOpenCompiledFolder } from '@renderer/hooks/use-open-compiled-folder.ts'
 
 export function DialogCompilationLogs({ children }: PropsWithChildren) {
   const { t } = useLingui()
@@ -33,6 +44,7 @@ export function DialogCompilationLogs({ children }: PropsWithChildren) {
     logsState(rawLogs)
   const { send } = useTelemetry()
   const { copyToClipboard } = useApp()
+  const openCompiledFolder = useOpenCompiledFolder()
   const [showErrorOnly, setShowErrorOnly] = useState(false)
   const [showFullPath, setShowFullPath] = useState(false)
 
@@ -106,7 +118,7 @@ export function DialogCompilationLogs({ children }: PropsWithChildren) {
                     <Trans>Aucune erreur !</Trans>
                   </li>
                 )}
-                {logs.map(({ script, output, success }) => {
+                {logs.map(({ script, output, success, pexPath }) => {
                   const onClickCopy = () => {
                     send(TelemetryEvent.compilationLogsCopy, {})
                     copyToClipboard(
@@ -119,6 +131,12 @@ export function DialogCompilationLogs({ children }: PropsWithChildren) {
 
                   const onClickDelete = () => {
                     clearCompilationLogs(script)
+                  }
+
+                  const onClickOpenFolder = () => {
+                    if (pexPath === undefined) return
+
+                    void openCompiledFolder(pexPath, 'logs')
                   }
 
                   return (
@@ -152,6 +170,26 @@ export function DialogCompilationLogs({ children }: PropsWithChildren) {
                             )}
                           </div>
                           <div className="flex gap-2">
+                            <Tooltip
+                              delayDuration={500}
+                              disableHoverableContent
+                            >
+                              <TooltipTrigger asChild>
+                                <Button
+                                  onClick={onClickOpenFolder}
+                                  size="icon"
+                                  disabled={pexPath === undefined}
+                                  aria-label={t`Ouvrir le dossier du script compilé`}
+                                >
+                                  <FolderOpenIcon />
+                                </Button>
+                              </TooltipTrigger>
+                              <TooltipContent>
+                                <Trans>
+                                  Ouvrir le dossier du script compilé
+                                </Trans>
+                              </TooltipContent>
+                            </Tooltip>
                             <Button onClick={onClickCopy} size="icon">
                               <ClipboardIcon />
                             </Button>

--- a/src/renderer/hooks/use-compilation.tsx
+++ b/src/renderer/hooks/use-compilation.tsx
@@ -99,6 +99,7 @@ function CompilationProvider({ children }: React.PropsWithChildren) {
                         status: result.success
                           ? ScriptStatus.success
                           : ScriptStatus.failed,
+                        pexPath: result.pexPath,
                       }
                     : c,
                 ),
@@ -106,7 +107,12 @@ function CompilationProvider({ children }: React.PropsWithChildren) {
 
               setCompilationLogs((cl) => {
                 return [
-                  { script: s, output: result.output, success: result.success },
+                  {
+                    script: s,
+                    output: result.output,
+                    success: result.success,
+                    pexPath: result.pexPath,
+                  },
                   ...cl,
                 ]
               })

--- a/src/renderer/hooks/use-open-compiled-folder.ts
+++ b/src/renderer/hooks/use-open-compiled-folder.ts
@@ -1,0 +1,39 @@
+/*
+ * 2026 Kiyozz.
+ */
+
+import { useLingui } from '@lingui/react/macro'
+import { useCallback } from 'react'
+import { toast } from 'sonner'
+import { TelemetryEvent } from '#common/telemetry-event.ts'
+import { bridge } from '../bridge'
+import { useTelemetry } from './use-telemetry'
+import type { TelemetryEventProperties } from '#common/telemetry-event.ts'
+
+type OpenFrom =
+  TelemetryEventProperties[TelemetryEvent.compilationOpenCompiledFolder]['from']
+
+/**
+ * Opens the folder the pex was written to, the file highlighted when it is
+ * still there.
+ */
+export function useOpenCompiledFolder(): (
+  pexPath: string,
+  from: OpenFrom,
+) => Promise<void> {
+  const { t } = useLingui()
+  const { send } = useTelemetry()
+
+  return useCallback(
+    async (pexPath: string, from: OpenFrom) => {
+      send(TelemetryEvent.compilationOpenCompiledFolder, { from })
+
+      const opened = await bridge.shell.showInFolder(pexPath)
+
+      if (!opened) {
+        toast.error(t`Impossible d'ouvrir le dossier`)
+      }
+    },
+    [send, t],
+  )
+}

--- a/src/renderer/locales/en/messages.po
+++ b/src/renderer/locales/en/messages.po
@@ -27,7 +27,7 @@ msgstr "About"
 msgid "Activer"
 msgstr "Enable"
 
-#: src/renderer/components/dialog/dialog-compilation-logs.tsx:208
+#: src/renderer/components/dialog/dialog-compilation-logs.tsx:235
 #: src/renderer/components/dialog/dialog-group.tsx:187
 #: src/renderer/components/dialog/dialog-recent-files.tsx:285
 msgid "Annuler"
@@ -37,7 +37,7 @@ msgstr "Cancel"
 msgid "Aucun fichiers récents."
 msgstr "No recent files."
 
-#: src/renderer/components/dialog/dialog-compilation-logs.tsx:103
+#: src/renderer/components/dialog/dialog-compilation-logs.tsx:109
 msgid "Aucun logs"
 msgstr "No logs"
 
@@ -45,7 +45,7 @@ msgstr "No logs"
 msgid "Aucun scripts"
 msgstr "No scripts"
 
-#: src/renderer/components/dialog/dialog-compilation-logs.tsx:112
+#: src/renderer/components/dialog/dialog-compilation-logs.tsx:118
 msgid "Aucune erreur !"
 msgstr "No errors!"
 
@@ -65,7 +65,7 @@ msgstr "Loading"
 msgid "Charger"
 msgstr "Load"
 
-#: src/renderer/components/dialog/dialog-compilation-logs.tsx:92
+#: src/renderer/components/dialog/dialog-compilation-logs.tsx:98
 msgid "Chemin complet"
 msgstr "Full path"
 
@@ -96,7 +96,7 @@ msgstr "Compilation"
 msgid "Configuration invalide"
 msgstr "Invalid configuration"
 
-#: src/renderer/components/dialog/dialog-compilation-logs.tsx:121
+#: src/renderer/components/dialog/dialog-compilation-logs.tsx:127
 msgid "Copier avec succès"
 msgstr "Successfully copied"
 
@@ -134,7 +134,7 @@ msgstr "Game folder"
 msgid "Dossier où se trouve {exe}"
 msgstr "Folder where {exe} is located"
 
-#: src/renderer/components/dialog/dialog-compilation-logs.tsx:159
+#: src/renderer/components/dialog/dialog-compilation-logs.tsx:168
 msgid "Échec"
 msgstr "Failed"
 
@@ -142,7 +142,7 @@ msgstr "Failed"
 msgid "Erreur"
 msgstr "Error"
 
-#: src/renderer/components/dialog/dialog-compilation-logs.tsx:82
+#: src/renderer/components/dialog/dialog-compilation-logs.tsx:88
 msgid "Erreurs uniquement"
 msgstr "Errors only"
 
@@ -166,6 +166,10 @@ msgstr "Group"
 #: src/renderer/pages/groups/groups-page.tsx:94
 msgid "Groupes"
 msgstr "Groups"
+
+#: src/renderer/hooks/use-open-compiled-folder.ts:34
+msgid "Impossible d'ouvrir le dossier"
+msgstr "Cannot open the folder"
 
 #: src/renderer/pages/settings/settings-preferences-section.tsx:114
 msgid "Info"
@@ -200,7 +204,7 @@ msgstr "Language"
 msgid "Logs"
 msgstr "Logs"
 
-#: src/renderer/components/dialog/dialog-compilation-logs.tsx:78
+#: src/renderer/components/dialog/dialog-compilation-logs.tsx:84
 msgid "Logs de compilation"
 msgstr "Compilation logs"
 
@@ -233,6 +237,13 @@ msgstr "Changelogs"
 msgid "Nouvelle version disponible : {latestVersion}"
 msgstr "New version available: {latestVersion}"
 
+#: src/renderer/components/dialog/dialog-compilation-logs.tsx:179
+#: src/renderer/components/dialog/dialog-compilation-logs.tsx:185
+#: src/renderer/pages/compilation/script-line.tsx:68
+#: src/renderer/pages/compilation/script-line.tsx:75
+msgid "Ouvrir le dossier du script compilé"
+msgstr "Open the compiled script folder"
+
 #: src/renderer/components/app-sidebar.tsx:44
 #: src/renderer/pages/settings/settings-page.tsx:258
 msgid "Paramètres"
@@ -257,7 +268,7 @@ msgid "Réduisez si vous rencontrez des blocages quand vous lancez la compilatio
 msgstr "Reduce if you experience latency when starting the compilation"
 
 #: src/renderer/components/dialog/dialog-group.tsx:158
-#: src/renderer/pages/compilation/script-line.tsx:52
+#: src/renderer/pages/compilation/script-line.tsx:84
 msgid "Retirer"
 msgstr "Remove"
 
@@ -282,7 +293,7 @@ msgstr "Select your game"
 msgid "Sombre"
 msgstr "Dark"
 
-#: src/renderer/components/dialog/dialog-compilation-logs.tsx:154
+#: src/renderer/components/dialog/dialog-compilation-logs.tsx:163
 msgid "Succès"
 msgstr "Success"
 
@@ -342,7 +353,7 @@ msgstr "Check that your Creation Kit installation is valid. PCA checks the prese
 msgid "Version"
 msgstr "Version"
 
-#: src/renderer/components/dialog/dialog-compilation-logs.tsx:202
+#: src/renderer/components/dialog/dialog-compilation-logs.tsx:229
 msgid "Vider"
 msgstr "Clear"
 

--- a/src/renderer/locales/fr/messages.po
+++ b/src/renderer/locales/fr/messages.po
@@ -27,7 +27,7 @@ msgstr "À propos"
 msgid "Activer"
 msgstr "Activer"
 
-#: src/renderer/components/dialog/dialog-compilation-logs.tsx:208
+#: src/renderer/components/dialog/dialog-compilation-logs.tsx:235
 #: src/renderer/components/dialog/dialog-group.tsx:187
 #: src/renderer/components/dialog/dialog-recent-files.tsx:285
 msgid "Annuler"
@@ -37,7 +37,7 @@ msgstr "Annuler"
 msgid "Aucun fichiers récents."
 msgstr "Aucun fichiers récents."
 
-#: src/renderer/components/dialog/dialog-compilation-logs.tsx:103
+#: src/renderer/components/dialog/dialog-compilation-logs.tsx:109
 msgid "Aucun logs"
 msgstr "Aucun logs"
 
@@ -45,7 +45,7 @@ msgstr "Aucun logs"
 msgid "Aucun scripts"
 msgstr "Aucun scripts"
 
-#: src/renderer/components/dialog/dialog-compilation-logs.tsx:112
+#: src/renderer/components/dialog/dialog-compilation-logs.tsx:118
 msgid "Aucune erreur !"
 msgstr "Aucune erreur !"
 
@@ -65,7 +65,7 @@ msgstr "Chargement"
 msgid "Charger"
 msgstr "Charger"
 
-#: src/renderer/components/dialog/dialog-compilation-logs.tsx:92
+#: src/renderer/components/dialog/dialog-compilation-logs.tsx:98
 msgid "Chemin complet"
 msgstr "Chemin complet"
 
@@ -96,7 +96,7 @@ msgstr "Compilation"
 msgid "Configuration invalide"
 msgstr "Configuration invalide"
 
-#: src/renderer/components/dialog/dialog-compilation-logs.tsx:121
+#: src/renderer/components/dialog/dialog-compilation-logs.tsx:127
 msgid "Copier avec succès"
 msgstr "Copier avec succès"
 
@@ -134,7 +134,7 @@ msgstr "Dossier du jeu"
 msgid "Dossier où se trouve {exe}"
 msgstr "Dossier où se trouve {exe}"
 
-#: src/renderer/components/dialog/dialog-compilation-logs.tsx:159
+#: src/renderer/components/dialog/dialog-compilation-logs.tsx:168
 msgid "Échec"
 msgstr "Échec"
 
@@ -142,7 +142,7 @@ msgstr "Échec"
 msgid "Erreur"
 msgstr "Erreur"
 
-#: src/renderer/components/dialog/dialog-compilation-logs.tsx:82
+#: src/renderer/components/dialog/dialog-compilation-logs.tsx:88
 msgid "Erreurs uniquement"
 msgstr "Erreurs uniquement"
 
@@ -166,6 +166,10 @@ msgstr "Groupe"
 #: src/renderer/pages/groups/groups-page.tsx:94
 msgid "Groupes"
 msgstr "Groupes"
+
+#: src/renderer/hooks/use-open-compiled-folder.ts:34
+msgid "Impossible d'ouvrir le dossier"
+msgstr "Impossible d'ouvrir le dossier"
 
 #: src/renderer/pages/settings/settings-preferences-section.tsx:114
 msgid "Info"
@@ -200,7 +204,7 @@ msgstr "Langue"
 msgid "Logs"
 msgstr "Logs"
 
-#: src/renderer/components/dialog/dialog-compilation-logs.tsx:78
+#: src/renderer/components/dialog/dialog-compilation-logs.tsx:84
 msgid "Logs de compilation"
 msgstr "Logs de compilation"
 
@@ -233,6 +237,13 @@ msgstr "Nouveautés"
 msgid "Nouvelle version disponible : {latestVersion}"
 msgstr "Nouvelle version disponible : {latestVersion}"
 
+#: src/renderer/components/dialog/dialog-compilation-logs.tsx:179
+#: src/renderer/components/dialog/dialog-compilation-logs.tsx:185
+#: src/renderer/pages/compilation/script-line.tsx:68
+#: src/renderer/pages/compilation/script-line.tsx:75
+msgid "Ouvrir le dossier du script compilé"
+msgstr "Ouvrir le dossier du script compilé"
+
 #: src/renderer/components/app-sidebar.tsx:44
 #: src/renderer/pages/settings/settings-page.tsx:258
 msgid "Paramètres"
@@ -257,7 +268,7 @@ msgid "Réduisez si vous rencontrez des blocages quand vous lancez la compilatio
 msgstr "Réduisez si vous rencontrez des blocages quand vous lancez la compilation"
 
 #: src/renderer/components/dialog/dialog-group.tsx:158
-#: src/renderer/pages/compilation/script-line.tsx:52
+#: src/renderer/pages/compilation/script-line.tsx:84
 msgid "Retirer"
 msgstr "Retirer"
 
@@ -282,7 +293,7 @@ msgstr "Sélectionner votre jeu"
 msgid "Sombre"
 msgstr "Sombre"
 
-#: src/renderer/components/dialog/dialog-compilation-logs.tsx:154
+#: src/renderer/components/dialog/dialog-compilation-logs.tsx:163
 msgid "Succès"
 msgstr "Succès"
 
@@ -342,7 +353,7 @@ msgstr "Vérifiez que votre installation de Creation Kit est valide. PCA vérifi
 msgid "Version"
 msgstr "Version"
 
-#: src/renderer/components/dialog/dialog-compilation-logs.tsx:202
+#: src/renderer/components/dialog/dialog-compilation-logs.tsx:229
 msgid "Vider"
 msgstr "Vider"
 

--- a/src/renderer/pages/compilation/script-line.tsx
+++ b/src/renderer/pages/compilation/script-line.tsx
@@ -7,8 +7,14 @@ import { useSettings } from '@renderer/pages/settings/use-settings.tsx'
 import type { ScriptRenderer } from '@renderer/types'
 import { IconFromStatus } from '@renderer/utils/scripts/from-status.tsx'
 import { isRunningScript } from '@renderer/utils/scripts/status.ts'
-import { PlayIcon, TrashIcon } from 'lucide-react'
-import { useLingui } from '@lingui/react/macro'
+import { FolderOpenIcon, PlayIcon, TrashIcon } from 'lucide-react'
+import { Trans, useLingui } from '@lingui/react/macro'
+import { useOpenCompiledFolder } from '@renderer/hooks/use-open-compiled-folder.ts'
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from '@renderer/components/ui/tooltip.tsx'
 
 interface ScriptLineProps {
   script: ScriptRenderer
@@ -23,6 +29,7 @@ function ScriptLine({
 }: ScriptLineProps) {
   const { t } = useLingui()
   const { configError } = useSettings()
+  const openCompiledFolder = useOpenCompiledFolder()
 
   const onClickRemove = () => {
     onClickRemoveScript(script)
@@ -30,6 +37,12 @@ function ScriptLine({
 
   const onClickPlay = () => {
     onClickPlayCompilation(script)
+  }
+
+  const onClickOpenFolder = () => {
+    if (script.pexPath === undefined) return
+
+    void openCompiledFolder(script.pexPath, 'script-line')
   }
 
   return (
@@ -44,6 +57,23 @@ function ScriptLine({
       </Button>
       <span className="flex-1 font-mono text-sm">{script.name}</span>
       <IconFromStatus script={script} className="size-4" />
+      <Tooltip delayDuration={500} disableHoverableContent>
+        <TooltipTrigger asChild>
+          <Button
+            size="icon-sm"
+            variant="secondary"
+            disabled={isRunningScript(script) || script.pexPath === undefined}
+            onClick={onClickOpenFolder}
+            aria-label={t`Ouvrir le dossier du script compilé`}
+            className="size-6"
+          >
+            <FolderOpenIcon className="size-3.5" />
+          </Button>
+        </TooltipTrigger>
+        <TooltipContent>
+          <Trans>Ouvrir le dossier du script compilé</Trans>
+        </TooltipContent>
+      </Tooltip>
       <Button
         size="icon-sm"
         disabled={isRunningScript(script)}

--- a/src/renderer/types/compilation-log.ts
+++ b/src/renderer/types/compilation-log.ts
@@ -8,4 +8,6 @@ export type CompilationLog = {
   script: ScriptRenderer
   output: string
   success: boolean
+  /** absolute path of the compiled pex, undefined when the compilation failed */
+  pexPath?: string
 }

--- a/src/renderer/types/script-renderer.ts
+++ b/src/renderer/types/script-renderer.ts
@@ -8,4 +8,6 @@ import type { ScriptStatus } from '../enums/script-status.enum'
 export type ScriptRenderer = Script & {
   id: string
   status: ScriptStatus
+  /** absolute path of the pex of the last run, undefined when it failed */
+  pexPath?: string
 }


### PR DESCRIPTION
## Issues

Closes #95

## Description

A compiled script gave no way back to where its pex landed - the more so with namespaces, where the pex sits in a subfolder of the output the user never picked.

**Where the pex is.** `PapyrusCompilerService.compile()` now returns `pexPath` along with the output and the resolved name. The compiler mirrors the namespace as folders under `-o`, so the path is built from the resolved name: `Mod:Sub:Script` -> `<output>/Mod/Sub/Script.pex`, plain `Script.psc` -> `<output>/Script.pex`. Nothing is probed on disk, it follows the same resolution that produced the compiler command. `CompilationResult.pexPath` is `undefined` when the run failed.

**Opening it.** New `shell.showInFolder(target)` on the main API: `showItemInFolder` when the pex is still there (Explorer opens with the file selected), otherwise `openPath` on the parent folder - the pex can have been moved or deleted since the run. Returns `false` when neither exists, and the renderer toasts an error.

**UI.** Button in both places a compiled script shows up:

- the script list, from `ScriptRenderer.pexPath` set at the end of each run (a failed run clears it)
- each entry of the compilation logs dialog, from the log entry's own `pexPath`

Always rendered, disabled until a run wrote a pex, so rows keep a stable layout. Tooltip with a 500 ms delay and `disableHoverableContent`. Shared action in `useOpenCompiledFolder()` (telemetry + bridge call + error toast), used by both.

Telemetry: `Compilation.OpenCompiledFolder` with `from: 'logs' | 'script-line'`.

## Notes

Catalogs extracted and translated (fr source, en).
