### PR TITLE
feat(diagnostic): warn on psc left in Scripts/Source for Skyrim SE and VR

### DIFF
--- a/.changeset/0027-skyrim-legacy-source-folder.md
+++ b/.changeset/0027-skyrim-legacy-source-folder.md
@@ -1,0 +1,7 @@
+---
+'pca': minor
+---
+
+Skyrim SE and VR: a warning when source scripts are left in `Data\Scripts\Source`, the Skyrim LE folder. Their Creation Kit only reads `Data\Source\Scripts`, and PCA imports the LE folder first, so an outdated copy of the game scripts left in there shadows the one the game ships and the compilation fails for no apparent reason. The report recommends moving everything to `Data\Source\Scripts` and opens the folder.
+
+The Compilation page now also raises the non blocking warnings, this one and the script extender without its sources, and no longer the errors only. An error still comes first when there is one.

--- a/src/common/types/diagnostic.ts
+++ b/src/common/types/diagnostic.ts
@@ -15,6 +15,8 @@ export type DiagnosticId =
   | 'compiler'
   /** neither archives nor psc, the kit is there but its sources are not */
   | 'sources-missing'
+  /** se and vr only: psc sit in the le source folder, which their kit ignores */
+  | 'sources-legacy'
   /** the compiler in use belongs to a game this one is not compatible with */
   | 'compiler-foreign'
   /** the script extender runs but did not bring its psc along */
@@ -40,6 +42,8 @@ export interface DiagnosticItem {
    * where the kit puts it
    */
   compilerPath?: string
+  /** on `sources-legacy`: the folder holding the misplaced psc */
+  sourcePath?: string
 }
 
 export interface Diagnostic {

--- a/src/main/event-handlers/config-diagnose.handler.ts
+++ b/src/main/event-handlers/config-diagnose.handler.ts
@@ -4,7 +4,9 @@
 
 // noinspection JSMethodCanBeStatic
 
+import { readdirSync } from 'node:fs'
 import {
+  GameSource,
   GameType,
   isCompilerCompatible,
   toCompilerSourceFile,
@@ -54,6 +56,24 @@ const ownerGame = (file: string): GameType | undefined => {
   }
 
   return undefined
+}
+
+/**
+ * Whether `folder` holds .psc right inside it. Only those count: an import
+ * root is handed to the compiler as is, it never walks into its subfolders.
+ */
+const holdsScripts = (folder: string): boolean => {
+  if (!path.exists(folder)) {
+    return false
+  }
+
+  try {
+    return readdirSync(folder).some((file) =>
+      file.toLowerCase().endsWith('.psc'),
+    )
+  } catch {
+    return false
+  }
 }
 
 const toDiagnosticArchive = (archive: ResolvedArchive): DiagnosticArchive => ({
@@ -132,6 +152,16 @@ export class ConfigDiagnoseHandler {
       }
     }
 
+    const legacySources = this.#legacySources(gamePath, gameType)
+
+    if (legacySources !== undefined) {
+      items.push({
+        id: 'sources-legacy',
+        severity: 'warning',
+        sourcePath: legacySources,
+      })
+    }
+
     if (this.#missesExtenderSources(gamePath, gameType)) {
       items.push({ id: 'extender-sources', severity: 'warning' })
     }
@@ -188,6 +218,26 @@ export class ConfigDiagnoseHandler {
     this.#logger.debug('the compiler belongs to', owner)
 
     return owner
+  }
+
+  /**
+   * The le source folder, `Data/Scripts/Source`, when the game has psc left in
+   * it. The games reading `Data/Source/Scripts` - Skyrim SE and VR - read that
+   * one only, so whatever sits in the le folder is invisible to their kit. PCA
+   * imports it, and before the game folder, to stay compatible: an outdated
+   * copy of the game scripts left there therefore shadows the one the game
+   * ships.
+   */
+  #legacySources(gamePath: GamePath, gameType: GameType): string | undefined {
+    if (toSource(gameType) !== GameSource.sourceFirst) {
+      return undefined
+    }
+
+    const folder = path.join(gamePath, 'Data', toOtherSource(gameType))
+
+    this.#logger.debug('checking the Skyrim LE source folder', folder)
+
+    return holdsScripts(folder) ? folder : undefined
   }
 
   #missesExtenderSources(gamePath: GamePath, gameType: GameType): boolean {

--- a/src/renderer/components/ck-diagnostic.tsx
+++ b/src/renderer/components/ck-diagnostic.tsx
@@ -95,6 +95,7 @@ function DiagnosticAlert({ item }: { item: DiagnosticItem }) {
       {item.id === 'sources-archived' && <SourcesArchived item={item} />}
       {item.id === 'compiler' && <CompilerMissing />}
       {item.id === 'sources-missing' && <SourcesMissing />}
+      {item.id === 'sources-legacy' && <SourcesLegacy item={item} />}
       {item.id === 'compiler-foreign' && <CompilerForeign item={item} />}
       {item.id === 'extender-sources' && <ExtenderSources />}
     </Alert>
@@ -396,6 +397,65 @@ function SourcesMissing() {
           <BookIcon />
           <Trans>Voir la documentation</Trans>
         </Button>
+      </AlertDescription>
+    </>
+  )
+}
+
+function SourcesLegacy({ item }: { item: DiagnosticItem }) {
+  const {
+    config: { game },
+  } = useApp()
+  const { open: openDocumentation } = useDocumentation()
+  const folder = item.sourcePath
+
+  return (
+    <>
+      <AlertTitle>
+        <Trans>Des scripts sources sont dans Scripts\Source</Trans>
+      </AlertTitle>
+      <AlertDescription className="flex flex-col items-start gap-3">
+        <div className="flex flex-col gap-2">
+          <span>
+            <Trans>
+              {game.type} range ses scripts sources dans Data\Source\Scripts, et
+              le Creation Kit ne lit que ce dossier. Data\Scripts\Source est
+              celui de Skyrim LE : tout ce qui y reste lui est invisible.
+            </Trans>
+          </span>
+          <span>
+            <Trans>
+              PCA, lui, l'importe avant Data\Source\Scripts : une ancienne copie
+              des scripts du jeu qui y traîne masque celle de {game.type}, et la
+              compilation échoue sans raison apparente.
+            </Trans>
+          </span>
+          <span>
+            <Trans>
+              Déplacez tout le contenu de Data\Scripts\Source vers
+              Data\Source\Scripts.
+            </Trans>
+          </span>
+        </div>
+        <div className="flex flex-wrap gap-2">
+          {folder !== undefined && (
+            <Button
+              onClick={() => void bridge.shell.showInFolder(folder)}
+              size="sm"
+            >
+              <FolderOpenIcon />
+              <Trans>Ouvrir le dossier</Trans>
+            </Button>
+          )}
+          <Button
+            onClick={() => openDocumentation('click')}
+            size="sm"
+            variant="outline"
+          >
+            <BookIcon />
+            <Trans>Voir la documentation</Trans>
+          </Button>
+        </div>
       </AlertDescription>
     </>
   )

--- a/src/renderer/locales/en/messages.po
+++ b/src/renderer/locales/en/messages.po
@@ -15,14 +15,19 @@ msgstr ""
 
 #. placeholder {0}: compilation.compilerPath
 #. placeholder {1}: toCompilerDir(game.type)
-#: src/renderer/components/ck-diagnostic.tsx:318
+#: src/renderer/components/ck-diagnostic.tsx:319
 msgid "\"{0}\" n'existe pas. Le Creation Kit installe PapyrusCompiler.exe dans le dossier \"{1}\" du jeu."
 msgstr "\"{0}\" does not exist. The Creation Kit installs PapyrusCompiler.exe in the game's \"{1}\" folder."
 
 #. placeholder {0}: extender.name
-#: src/renderer/components/ck-diagnostic.tsx:417
+#: src/renderer/components/ck-diagnostic.tsx:477
 msgid "{0} est installé, sans ses scripts sources"
 msgstr "{0} is installed, without its source scripts"
+
+#. placeholder {0}: game.type
+#: src/renderer/components/ck-diagnostic.tsx:420
+msgid "{0} range ses scripts sources dans Data\\Source\\Scripts, et le Creation Kit ne lit que ce dossier. Data\\Scripts\\Source est celui de Skyrim LE : tout ce qui y reste lui est invisible."
+msgstr "{0} keeps its source scripts in Data\\Source\\Scripts, and the Creation Kit reads that folder only. Data\\Scripts\\Source is the Skyrim LE one: whatever stays in there is invisible to it."
 
 #. placeholder {0}: pscScripts.length
 #: src/renderer/pages/compilation/compilation-page.tsx:115
@@ -44,7 +49,7 @@ msgstr "Enable"
 msgid "Annuler"
 msgstr "Cancel"
 
-#: src/renderer/components/ck-diagnostic.tsx:206
+#: src/renderer/components/ck-diagnostic.tsx:207
 msgid "Archives extraites"
 msgstr "Archives extracted"
 
@@ -76,11 +81,11 @@ msgstr "Warning"
 #~ msgid "C'est volontaire si vous utilisez le Creation Kit d'un autre jeu compatible, ou un compilateur Papyrus tiers."
 #~ msgstr "This is intended if you use the Creation Kit of another compatible game, or a third party Papyrus compiler."
 
-#: src/renderer/components/ck-diagnostic.tsx:149
+#: src/renderer/components/ck-diagnostic.tsx:150
 msgid "Ce Creation Kit n'a pas de page dans le magasin : dans Steam, ouvrez Bibliothèque puis Outils pour l'installer."
 msgstr "This Creation Kit has no store page: in Steam, open Library then Tools to install it."
 
-#: src/renderer/pages/compilation/compilation-page.tsx:268
+#: src/renderer/pages/compilation/compilation-page.tsx:279
 msgid "Cette fonctionnalité n'est pas disponible si PCA est lancé en mode administrateur."
 msgstr "This feature is not available when running PCA in administrator."
 
@@ -100,7 +105,7 @@ msgstr "Full path"
 msgid "Chemin vers le fichier PapyrusCompiler.exe. Le fichier est disponible après l'installation de CreationKit. Plus d'informations sur la documentation de PCA."
 msgstr "Path to PapyrusCompiler.exe. This file comes from the CreationKit installation. More details on PCA's documentation."
 
-#: src/renderer/components/ck-diagnostic.tsx:295
+#: src/renderer/components/ck-diagnostic.tsx:296
 msgid "Choisir PapyrusCompiler.exe"
 msgstr "Select PapyrusCompiler.exe"
 
@@ -114,7 +119,7 @@ msgstr "Choose the folder that contains {0}."
 msgid "Clair"
 msgstr "Light"
 
-#: src/renderer/pages/compilation/compilation-page.tsx:257
+#: src/renderer/pages/compilation/compilation-page.tsx:268
 msgid "Commencez par glisser-déposer des fichiers psc pour les charger"
 msgstr "Start by dropping psc files to load them"
 
@@ -122,7 +127,7 @@ msgstr "Start by dropping psc files to load them"
 msgid "Compilateur Papyrus"
 msgstr "Papyrus Compiler"
 
-#: src/renderer/components/ck-diagnostic.tsx:308
+#: src/renderer/components/ck-diagnostic.tsx:309
 msgid "Compilateur Papyrus introuvable"
 msgstr "Papyrus compiler not found"
 
@@ -131,7 +136,7 @@ msgid "Compilateur utilisé"
 msgstr "Compiler in use"
 
 #: src/renderer/components/app-sidebar.tsx:34
-#: src/renderer/pages/compilation/compilation-page.tsx:231
+#: src/renderer/pages/compilation/compilation-page.tsx:242
 #: src/renderer/pages/settings/settings-compilation.tsx:21
 msgid "Compilation"
 msgstr "Compilation"
@@ -140,7 +145,7 @@ msgstr "Compilation"
 msgid "Configuration de PCA"
 msgstr "PCA setup"
 
-#: src/renderer/pages/compilation/compilation-page.tsx:198
+#: src/renderer/pages/compilation/compilation-page.tsx:206
 msgid "Configuration invalide"
 msgstr "Invalid configuration"
 
@@ -148,7 +153,7 @@ msgstr "Invalid configuration"
 msgid "Copier avec succès"
 msgstr "Successfully copied"
 
-#: src/renderer/components/ck-diagnostic.tsx:119
+#: src/renderer/components/ck-diagnostic.tsx:120
 msgid "Creation Kit non installé"
 msgstr "Creation Kit not installed"
 
@@ -160,13 +165,25 @@ msgstr "Create"
 msgid "Debug"
 msgstr "Debug"
 
+#: src/renderer/components/ck-diagnostic.tsx:434
+msgid "Déplacez tout le contenu de Data\\Scripts\\Source vers Data\\Source\\Scripts."
+msgstr "Move everything in Data\\Scripts\\Source to Data\\Source\\Scripts."
+
 #: src/renderer/pages/settings/settings-mo2/settings-mo2.tsx:35
 msgid "Depuis la version 5.9.0, l'intégration MO2 a été supprimée. Configurez PCA pour être lancé via MO2 à la place."
 msgstr "Since version 5.9.0, the MO2 integration has been removed. Configure PCA to be launched via MO2 instead."
 
-#: src/renderer/pages/compilation/compilation-page.tsx:191
+#: src/renderer/pages/compilation/compilation-page.tsx:195
 msgid "Des archives de scripts sources restent à extraire."
 msgstr "Some source script archives still have to be extracted."
+
+#: src/renderer/components/ck-diagnostic.tsx:415
+msgid "Des scripts sources sont dans Scripts\\Source"
+msgstr "Source scripts are sitting in Scripts\\Source"
+
+#: src/renderer/pages/compilation/compilation-page.tsx:198
+msgid "Des scripts sources sont dans Scripts\\Source au lieu de Source\\Scripts."
+msgstr "Source scripts are sitting in Scripts\\Source instead of Source\\Scripts."
 
 #: src/renderer/components/app-sidebar.tsx:57
 #: src/renderer/pages/settings/settings-page.tsx:273
@@ -208,7 +225,7 @@ msgstr "Errors only"
 msgid "Étape {0} sur {1}"
 msgstr "Step {0} of {1}"
 
-#: src/renderer/components/ck-diagnostic.tsx:255
+#: src/renderer/components/ck-diagnostic.tsx:256
 msgid "Extraction…"
 msgstr "Extracting…"
 
@@ -233,7 +250,7 @@ msgstr "Group"
 msgid "Groupes"
 msgstr "Groups"
 
-#: src/renderer/components/ck-diagnostic.tsx:132
+#: src/renderer/components/ck-diagnostic.tsx:133
 msgid "Il n'existe pas de Creation Kit pour Skyrim VR : installez celui de Skyrim Special Edition, et choisissez le dossier de Skyrim VR au moment de l'installation dans Steam."
 msgstr "There is no Creation Kit for Skyrim VR: install the Skyrim Special Edition one, and choose your Skyrim VR folder when Steam asks where to install it."
 
@@ -249,7 +266,7 @@ msgstr "Cannot open the folder"
 msgid "Info"
 msgstr "Info"
 
-#: src/renderer/components/ck-diagnostic.tsx:162
+#: src/renderer/components/ck-diagnostic.tsx:163
 msgid "Installer via Steam"
 msgstr "Install from Steam"
 
@@ -261,15 +278,19 @@ msgstr "MO2 integration removed"
 msgid "Jeu"
 msgstr "Game"
 
-#: src/renderer/components/ck-diagnostic.tsx:211
+#: src/renderer/components/ck-diagnostic.tsx:212
 msgid "L'extraction a échoué"
 msgstr "Extraction failed"
 
 #. placeholder {0}: extender.name
 #. placeholder {1}: extender.name
-#: src/renderer/components/ck-diagnostic.tsx:421
+#: src/renderer/components/ck-diagnostic.tsx:481
 msgid "La compilation fonctionne, mais tout script utilisant une fonction de {0} échouera. Copiez le dossier Data\\Scripts\\Source de l'archive {1} dans le dossier du jeu."
 msgstr "Compilation works, but any script using a {0} function will fail. Copy the Data\\Scripts\\Source folder of the {1} archive into the game folder."
+
+#: src/renderer/pages/compilation/compilation-page.tsx:207
+msgid "La compilation peut échouer"
+msgstr "The compilation may fail"
 
 #: src/renderer/pages/settings/settings-game-section.tsx:130
 #~ msgid "La configuration semble invalide :"
@@ -279,7 +300,7 @@ msgstr "Compilation works, but any script using a {0} function will fail. Copy t
 msgid "Laissez vide pour utiliser le dossier par défaut du jeu (Data/Scripts)."
 msgstr "Leave empty to use the default game folder (Data/Scripts)."
 
-#: src/renderer/pages/compilation/compilation-page.tsx:288
+#: src/renderer/pages/compilation/compilation-page.tsx:299
 msgid "Lancer"
 msgstr "Start"
 
@@ -293,7 +314,7 @@ msgstr "Language"
 #~ msgstr "The compiler does not come from this game"
 
 #. placeholder {0}: item.game
-#: src/renderer/components/ck-diagnostic.tsx:345
+#: src/renderer/components/ck-diagnostic.tsx:346
 msgid "Le compilateur vient de {0}"
 msgstr "The compiler comes from {0}"
 
@@ -302,25 +323,29 @@ msgid "Le Creation Kit est correctement installé, tout est prêt."
 msgstr "The Creation Kit is correctly installed, everything is ready."
 
 #. placeholder {0}: toCompilerDir(game.type)
-#: src/renderer/components/ck-diagnostic.tsx:313
+#: src/renderer/components/ck-diagnostic.tsx:314
 msgid "Le Creation Kit installe PapyrusCompiler.exe dans le dossier \"{0}\" du jeu."
 msgstr "The Creation Kit installs PapyrusCompiler.exe in the \"{0}\" folder of the game."
 
-#: src/renderer/components/ck-diagnostic.tsx:230
+#: src/renderer/components/ck-diagnostic.tsx:231
 msgid "Le Creation Kit livre les scripts sources du jeu dans des archives. Tant qu'elles ne sont pas extraites, la compilation échoue."
 msgstr "The Creation Kit ships the game source scripts inside archives. Compilation fails until they are extracted."
 
-#: src/renderer/pages/compilation/compilation-page.tsx:190
+#: src/renderer/pages/compilation/compilation-page.tsx:194
 msgid "Le Creation Kit n'est pas installé."
 msgstr "The Creation Kit is not installed."
 
-#: src/renderer/components/ck-diagnostic.tsx:213
+#: src/renderer/components/ck-diagnostic.tsx:214
 msgid "Le dossier du jeu est protégé en écriture. Extrayez les archives vous-même, ou installez le jeu hors de Program Files."
 msgstr "The game folder is write protected. Extract the archives yourself, or install the game outside of Program Files."
 
 #: src/renderer/components/ck-diagnostic.tsx:84
 msgid "Le jeu est introuvable"
 msgstr "The game cannot be found"
+
+#: src/renderer/pages/compilation/compilation-page.tsx:201
+msgid "Le script extender est installé sans ses scripts sources."
+msgstr "The script extender is installed without its source scripts."
 
 #: src/renderer/components/app-sidebar.tsx:52
 msgid "Logs"
@@ -364,7 +389,8 @@ msgstr "New version available: {latestVersion}"
 msgid "Où est installé {0} ?"
 msgstr "Where is {0} installed?"
 
-#: src/renderer/components/ck-diagnostic.tsx:268
+#: src/renderer/components/ck-diagnostic.tsx:269
+#: src/renderer/components/ck-diagnostic.tsx:447
 msgid "Ouvrir le dossier"
 msgstr "Open the folder"
 
@@ -385,7 +411,7 @@ msgid "Parcourir"
 msgstr "Browse"
 
 #. placeholder {0}: toCompilerSourceFile(game.type)
-#: src/renderer/components/ck-diagnostic.tsx:385
+#: src/renderer/components/ck-diagnostic.tsx:386
 msgid "PCA cherche le fichier {0} dans les dossiers Scripts\\Source ou Source\\Scripts du dossier Data du jeu pour valider l'installation du Creation Kit."
 msgstr "PCA looks for {0} in the Scripts\\Source or Source\\Scripts folders of the game Data folder to validate the Creation Kit installation."
 
@@ -402,13 +428,13 @@ msgstr "PCA compiles the Papyrus scripts of this game. You can change it at any 
 #. placeholder {0}: game.type
 #. placeholder {1}: compilation.compilerPath
 #. placeholder {2}: item.game
-#: src/renderer/components/ck-diagnostic.tsx:349
+#: src/renderer/components/ck-diagnostic.tsx:350
 msgid "PCA compilerait du {0} avec \"{1}\", qui appartient à {2}. Ces compilateurs ne sont pas interchangeables. Si vous venez de changer de jeu, c'est un reste du précédent."
 msgstr "PCA would compile {0} with \"{1}\", which belongs to {2}. These compilers are not interchangeable. If you just switched games, this is a leftover from the previous one."
 
 #. placeholder {0}: game.type
 #. placeholder {1}: ck.name
-#: src/renderer/components/ck-diagnostic.tsx:124
+#: src/renderer/components/ck-diagnostic.tsx:125
 msgid "PCA n'a trouvé aucun script source de {0}. Le Creation Kit s'installe gratuitement depuis Steam, en cherchant \"{1}\", et dépose ces scripts dans le dossier du jeu."
 msgstr "PCA found no {0} source script. The Creation Kit installs for free from Steam, search for \"{1}\", and it drops those scripts into the game folder."
 
@@ -417,12 +443,21 @@ msgstr "PCA found no {0} source script. The Creation Kit installs for free from 
 #~ msgid "PCA n'a trouvé ni le compilateur Papyrus, ni les scripts sources du jeu. Le Creation Kit s'installe gratuitement depuis Steam, en cherchant \"{0}\"."
 #~ msgstr "PCA found neither the Papyrus compiler nor the game source scripts. The Creation Kit installs for free from Steam, search for \"{0}\"."
 
-#: src/renderer/components/ck-diagnostic.tsx:243
+#: src/renderer/components/ck-diagnostic.tsx:244
 msgid "PCA ne sait pas ouvrir une archive .rar : extrayez-la vous-même avec 7-Zip ou WinRAR, en conservant les dossiers."
 msgstr "PCA cannot open a .rar archive: extract it yourself with 7-Zip or WinRAR, keeping the folders."
 
+#. placeholder {0}: game.type
+#: src/renderer/components/ck-diagnostic.tsx:427
+msgid "PCA, lui, l'importe avant Data\\Source\\Scripts : une ancienne copie des scripts du jeu qui y traîne masque celle de {0}, et la compilation échoue sans raison apparente."
+msgstr "PCA does import it, and before Data\\Source\\Scripts: an old copy of the game scripts left in there hides the {0} one, and the compilation fails for no apparent reason."
+
+#: src/renderer/components/ck-diagnostic.tsx:425
+#~ msgid "PCA, lui, l'importe avant Data\\Source\\Scripts : une ancienne copie des scripts du jeu qui y traîne masque celle de Special Edition, et la compilation échoue sans raison apparente."
+#~ msgstr "PCA does import it, and before Data\\Source\\Scripts: an old copy of the game scripts left in there hides the Special Edition one, and the compilation fails for no apparent reason."
+
 #: src/renderer/components/dialog/dialog-recent-files.tsx:276
-#: src/renderer/pages/compilation/compilation-page.tsx:210
+#: src/renderer/pages/compilation/compilation-page.tsx:220
 #: src/renderer/pages/groups/groups-page.tsx:118
 msgid "Plus de détails"
 msgstr "More details"
@@ -456,11 +491,11 @@ msgstr "Remove"
 msgid "Retour"
 msgstr "Back"
 
-#: src/renderer/components/ck-diagnostic.tsx:381
+#: src/renderer/components/ck-diagnostic.tsx:382
 msgid "Scripts sources introuvables"
 msgstr "Source scripts not found"
 
-#: src/renderer/components/ck-diagnostic.tsx:225
+#: src/renderer/components/ck-diagnostic.tsx:226
 msgid "Scripts sources non extraits"
 msgstr "Source scripts not extracted"
 
@@ -482,9 +517,13 @@ msgid "Sélectionner votre jeu"
 msgstr "Select your game"
 
 #. placeholder {0}: game.type
-#: src/renderer/components/ck-diagnostic.tsx:140
+#: src/renderer/components/ck-diagnostic.tsx:141
 msgid "Si vous avez déjà un PapyrusCompiler.exe ailleurs, vous pouvez le désigner : celui de Skyrim Special Edition compile aussi bien pour Skyrim VR. Les scripts sources, eux, doivent se trouver dans le dossier de {0}."
 msgstr "If you already have a PapyrusCompiler.exe elsewhere, you can point at it: the Skyrim Special Edition one compiles for Skyrim VR just as well. The source scripts, however, have to sit in the {0} folder."
+
+#: src/renderer/components/ck-diagnostic.tsx:417
+#~ msgid "Skyrim Special Edition range ses scripts sources dans Data\\Source\\Scripts, et le Creation Kit ne lit que ce dossier. Data\\Scripts\\Source est celui de Skyrim LE : tout ce qui y reste lui est invisible."
+#~ msgstr "Skyrim Special Edition keeps its source scripts in Data\\Source\\Scripts, and the Creation Kit reads that folder only. Data\\Scripts\\Source is the Skyrim LE one: whatever stays in there is invisible to it."
 
 #: src/renderer/pages/settings/settings-preferences-section.tsx:57
 #: src/renderer/pages/settings/settings-theme-section.tsx:50
@@ -513,7 +552,7 @@ msgid "Télécharger"
 msgstr "Download"
 
 #. placeholder {0}: extender.name
-#: src/renderer/components/ck-diagnostic.tsx:433
+#: src/renderer/components/ck-diagnostic.tsx:493
 msgid "Télécharger {0}"
 msgstr "Download {0}"
 
@@ -534,7 +573,7 @@ msgstr "All recent files are already loaded."
 msgid "Tout est prêt. Glissez vos fichiers .psc dans la page Compilation, ou utilisez le bouton d'ajout."
 msgstr "Everything is ready. Drop your .psc files onto the Compilation page, or use the add button."
 
-#: src/renderer/components/ck-diagnostic.tsx:257
+#: src/renderer/components/ck-diagnostic.tsx:258
 msgid "Tout extraire"
 msgstr "Extract all"
 
@@ -543,7 +582,7 @@ msgid "Un groupe est un ensemble de scripts qui peut être ajoutés rapidement �
 msgstr "A group is a set of scripts that can be easily loaded on the compilation view."
 
 #. placeholder {0}: game.type
-#: src/renderer/components/ck-diagnostic.tsx:362
+#: src/renderer/components/ck-diagnostic.tsx:363
 msgid "Utiliser celui de {0}"
 msgstr "Use the {0} one"
 
@@ -551,15 +590,15 @@ msgstr "Use the {0} one"
 msgid "Vérifier à nouveau"
 msgstr "Check again"
 
-#: src/renderer/pages/compilation/compilation-page.tsx:193
+#: src/renderer/pages/compilation/compilation-page.tsx:197
 msgid "Vérifiez l'installation de Creation Kit."
 msgstr "Check your Creation Kit installation."
 
-#: src/renderer/pages/compilation/compilation-page.tsx:192
+#: src/renderer/pages/compilation/compilation-page.tsx:196
 msgid "Vérifiez le chemin du compilateur."
 msgstr "Check your compiler path."
 
-#: src/renderer/pages/compilation/compilation-page.tsx:189
+#: src/renderer/pages/compilation/compilation-page.tsx:193
 msgid "Vérifiez le chemin du jeu."
 msgstr "Check your game path."
 
@@ -590,15 +629,16 @@ msgstr "Version"
 msgid "Vider"
 msgstr "Clear"
 
-#: src/renderer/pages/compilation/compilation-page.tsx:300
+#: src/renderer/pages/compilation/compilation-page.tsx:311
 msgid "Vider la liste"
 msgstr "Clear list"
 
-#: src/renderer/components/ck-diagnostic.tsx:397
+#: src/renderer/components/ck-diagnostic.tsx:398
+#: src/renderer/components/ck-diagnostic.tsx:456
 msgid "Voir la documentation"
 msgstr "See the documentation"
 
-#: src/renderer/components/ck-diagnostic.tsx:170
+#: src/renderer/components/ck-diagnostic.tsx:171
 msgid "Voir sur le magasin Steam"
 msgstr "View on the Steam store"
 

--- a/src/renderer/locales/fr/messages.po
+++ b/src/renderer/locales/fr/messages.po
@@ -15,14 +15,19 @@ msgstr ""
 
 #. placeholder {0}: compilation.compilerPath
 #. placeholder {1}: toCompilerDir(game.type)
-#: src/renderer/components/ck-diagnostic.tsx:318
+#: src/renderer/components/ck-diagnostic.tsx:319
 msgid "\"{0}\" n'existe pas. Le Creation Kit installe PapyrusCompiler.exe dans le dossier \"{1}\" du jeu."
 msgstr "\"{0}\" n'existe pas. Le Creation Kit installe PapyrusCompiler.exe dans le dossier \"{1}\" du jeu."
 
 #. placeholder {0}: extender.name
-#: src/renderer/components/ck-diagnostic.tsx:417
+#: src/renderer/components/ck-diagnostic.tsx:477
 msgid "{0} est installé, sans ses scripts sources"
 msgstr "{0} est installé, sans ses scripts sources"
+
+#. placeholder {0}: game.type
+#: src/renderer/components/ck-diagnostic.tsx:420
+msgid "{0} range ses scripts sources dans Data\\Source\\Scripts, et le Creation Kit ne lit que ce dossier. Data\\Scripts\\Source est celui de Skyrim LE : tout ce qui y reste lui est invisible."
+msgstr "{0} range ses scripts sources dans Data\\Source\\Scripts, et le Creation Kit ne lit que ce dossier. Data\\Scripts\\Source est celui de Skyrim LE : tout ce qui y reste lui est invisible."
 
 #. placeholder {0}: pscScripts.length
 #: src/renderer/pages/compilation/compilation-page.tsx:115
@@ -44,7 +49,7 @@ msgstr "Activer"
 msgid "Annuler"
 msgstr "Annuler"
 
-#: src/renderer/components/ck-diagnostic.tsx:206
+#: src/renderer/components/ck-diagnostic.tsx:207
 msgid "Archives extraites"
 msgstr "Archives extraites"
 
@@ -76,11 +81,11 @@ msgstr "Avertissement"
 #~ msgid "C'est volontaire si vous utilisez le Creation Kit d'un autre jeu compatible, ou un compilateur Papyrus tiers."
 #~ msgstr "C'est volontaire si vous utilisez le Creation Kit d'un autre jeu compatible, ou un compilateur Papyrus tiers."
 
-#: src/renderer/components/ck-diagnostic.tsx:149
+#: src/renderer/components/ck-diagnostic.tsx:150
 msgid "Ce Creation Kit n'a pas de page dans le magasin : dans Steam, ouvrez Bibliothèque puis Outils pour l'installer."
 msgstr "Ce Creation Kit n'a pas de page dans le magasin : dans Steam, ouvrez Bibliothèque puis Outils pour l'installer."
 
-#: src/renderer/pages/compilation/compilation-page.tsx:268
+#: src/renderer/pages/compilation/compilation-page.tsx:279
 msgid "Cette fonctionnalité n'est pas disponible si PCA est lancé en mode administrateur."
 msgstr "Cette fonctionnalité n'est pas disponible si PCA est lancé en mode administrateur."
 
@@ -100,7 +105,7 @@ msgstr "Chemin complet"
 msgid "Chemin vers le fichier PapyrusCompiler.exe. Le fichier est disponible après l'installation de CreationKit. Plus d'informations sur la documentation de PCA."
 msgstr "Chemin vers le fichier PapyrusCompiler.exe. Le fichier est disponible après l'installation de CreationKit. Plus d'informations sur la documentation de PCA."
 
-#: src/renderer/components/ck-diagnostic.tsx:295
+#: src/renderer/components/ck-diagnostic.tsx:296
 msgid "Choisir PapyrusCompiler.exe"
 msgstr "Choisir PapyrusCompiler.exe"
 
@@ -114,7 +119,7 @@ msgstr "Choisissez le dossier qui contient {0}."
 msgid "Clair"
 msgstr "Clair"
 
-#: src/renderer/pages/compilation/compilation-page.tsx:257
+#: src/renderer/pages/compilation/compilation-page.tsx:268
 msgid "Commencez par glisser-déposer des fichiers psc pour les charger"
 msgstr "Commencez par glisser-déposer des fichiers psc pour les charger"
 
@@ -122,7 +127,7 @@ msgstr "Commencez par glisser-déposer des fichiers psc pour les charger"
 msgid "Compilateur Papyrus"
 msgstr "Compilateur Papyrus"
 
-#: src/renderer/components/ck-diagnostic.tsx:308
+#: src/renderer/components/ck-diagnostic.tsx:309
 msgid "Compilateur Papyrus introuvable"
 msgstr "Compilateur Papyrus introuvable"
 
@@ -131,7 +136,7 @@ msgid "Compilateur utilisé"
 msgstr "Compilateur utilisé"
 
 #: src/renderer/components/app-sidebar.tsx:34
-#: src/renderer/pages/compilation/compilation-page.tsx:231
+#: src/renderer/pages/compilation/compilation-page.tsx:242
 #: src/renderer/pages/settings/settings-compilation.tsx:21
 msgid "Compilation"
 msgstr "Compilation"
@@ -140,7 +145,7 @@ msgstr "Compilation"
 msgid "Configuration de PCA"
 msgstr "Configuration de PCA"
 
-#: src/renderer/pages/compilation/compilation-page.tsx:198
+#: src/renderer/pages/compilation/compilation-page.tsx:206
 msgid "Configuration invalide"
 msgstr "Configuration invalide"
 
@@ -148,7 +153,7 @@ msgstr "Configuration invalide"
 msgid "Copier avec succès"
 msgstr "Copier avec succès"
 
-#: src/renderer/components/ck-diagnostic.tsx:119
+#: src/renderer/components/ck-diagnostic.tsx:120
 msgid "Creation Kit non installé"
 msgstr "Creation Kit non installé"
 
@@ -160,13 +165,25 @@ msgstr "Créer"
 msgid "Debug"
 msgstr "Debug"
 
+#: src/renderer/components/ck-diagnostic.tsx:434
+msgid "Déplacez tout le contenu de Data\\Scripts\\Source vers Data\\Source\\Scripts."
+msgstr "Déplacez tout le contenu de Data\\Scripts\\Source vers Data\\Source\\Scripts."
+
 #: src/renderer/pages/settings/settings-mo2/settings-mo2.tsx:35
 msgid "Depuis la version 5.9.0, l'intégration MO2 a été supprimée. Configurez PCA pour être lancé via MO2 à la place."
 msgstr "Depuis la version 5.9.0, l'intégration MO2 a été supprimée. Configurez PCA pour être lancé via MO2 à la place."
 
-#: src/renderer/pages/compilation/compilation-page.tsx:191
+#: src/renderer/pages/compilation/compilation-page.tsx:195
 msgid "Des archives de scripts sources restent à extraire."
 msgstr "Des archives de scripts sources restent à extraire."
+
+#: src/renderer/components/ck-diagnostic.tsx:415
+msgid "Des scripts sources sont dans Scripts\\Source"
+msgstr "Des scripts sources sont dans Scripts\\Source"
+
+#: src/renderer/pages/compilation/compilation-page.tsx:198
+msgid "Des scripts sources sont dans Scripts\\Source au lieu de Source\\Scripts."
+msgstr "Des scripts sources sont dans Scripts\\Source au lieu de Source\\Scripts."
 
 #: src/renderer/components/app-sidebar.tsx:57
 #: src/renderer/pages/settings/settings-page.tsx:273
@@ -208,7 +225,7 @@ msgstr "Erreurs uniquement"
 msgid "Étape {0} sur {1}"
 msgstr "Étape {0} sur {1}"
 
-#: src/renderer/components/ck-diagnostic.tsx:255
+#: src/renderer/components/ck-diagnostic.tsx:256
 msgid "Extraction…"
 msgstr "Extraction…"
 
@@ -233,7 +250,7 @@ msgstr "Groupe"
 msgid "Groupes"
 msgstr "Groupes"
 
-#: src/renderer/components/ck-diagnostic.tsx:132
+#: src/renderer/components/ck-diagnostic.tsx:133
 msgid "Il n'existe pas de Creation Kit pour Skyrim VR : installez celui de Skyrim Special Edition, et choisissez le dossier de Skyrim VR au moment de l'installation dans Steam."
 msgstr "Il n'existe pas de Creation Kit pour Skyrim VR : installez celui de Skyrim Special Edition, et choisissez le dossier de Skyrim VR au moment de l'installation dans Steam."
 
@@ -249,7 +266,7 @@ msgstr "Impossible d'ouvrir le dossier"
 msgid "Info"
 msgstr "Info"
 
-#: src/renderer/components/ck-diagnostic.tsx:162
+#: src/renderer/components/ck-diagnostic.tsx:163
 msgid "Installer via Steam"
 msgstr "Installer via Steam"
 
@@ -261,15 +278,19 @@ msgstr "Intégration MO2 supprimée"
 msgid "Jeu"
 msgstr "Jeu"
 
-#: src/renderer/components/ck-diagnostic.tsx:211
+#: src/renderer/components/ck-diagnostic.tsx:212
 msgid "L'extraction a échoué"
 msgstr "L'extraction a échoué"
 
 #. placeholder {0}: extender.name
 #. placeholder {1}: extender.name
-#: src/renderer/components/ck-diagnostic.tsx:421
+#: src/renderer/components/ck-diagnostic.tsx:481
 msgid "La compilation fonctionne, mais tout script utilisant une fonction de {0} échouera. Copiez le dossier Data\\Scripts\\Source de l'archive {1} dans le dossier du jeu."
 msgstr "La compilation fonctionne, mais tout script utilisant une fonction de {0} échouera. Copiez le dossier Data\\Scripts\\Source de l'archive {1} dans le dossier du jeu."
+
+#: src/renderer/pages/compilation/compilation-page.tsx:207
+msgid "La compilation peut échouer"
+msgstr "La compilation peut échouer"
 
 #: src/renderer/pages/settings/settings-game-section.tsx:130
 #~ msgid "La configuration semble invalide :"
@@ -279,7 +300,7 @@ msgstr "La compilation fonctionne, mais tout script utilisant une fonction de {0
 msgid "Laissez vide pour utiliser le dossier par défaut du jeu (Data/Scripts)."
 msgstr "Laissez vide pour utiliser le dossier par défaut du jeu (Data/Scripts)."
 
-#: src/renderer/pages/compilation/compilation-page.tsx:288
+#: src/renderer/pages/compilation/compilation-page.tsx:299
 msgid "Lancer"
 msgstr "Lancer"
 
@@ -293,7 +314,7 @@ msgstr "Langue"
 #~ msgstr "Le compilateur ne vient pas de ce jeu"
 
 #. placeholder {0}: item.game
-#: src/renderer/components/ck-diagnostic.tsx:345
+#: src/renderer/components/ck-diagnostic.tsx:346
 msgid "Le compilateur vient de {0}"
 msgstr "Le compilateur vient de {0}"
 
@@ -302,25 +323,29 @@ msgid "Le Creation Kit est correctement installé, tout est prêt."
 msgstr "Le Creation Kit est correctement installé, tout est prêt."
 
 #. placeholder {0}: toCompilerDir(game.type)
-#: src/renderer/components/ck-diagnostic.tsx:313
+#: src/renderer/components/ck-diagnostic.tsx:314
 msgid "Le Creation Kit installe PapyrusCompiler.exe dans le dossier \"{0}\" du jeu."
 msgstr "Le Creation Kit installe PapyrusCompiler.exe dans le dossier \"{0}\" du jeu."
 
-#: src/renderer/components/ck-diagnostic.tsx:230
+#: src/renderer/components/ck-diagnostic.tsx:231
 msgid "Le Creation Kit livre les scripts sources du jeu dans des archives. Tant qu'elles ne sont pas extraites, la compilation échoue."
 msgstr "Le Creation Kit livre les scripts sources du jeu dans des archives. Tant qu'elles ne sont pas extraites, la compilation échoue."
 
-#: src/renderer/pages/compilation/compilation-page.tsx:190
+#: src/renderer/pages/compilation/compilation-page.tsx:194
 msgid "Le Creation Kit n'est pas installé."
 msgstr "Le Creation Kit n'est pas installé."
 
-#: src/renderer/components/ck-diagnostic.tsx:213
+#: src/renderer/components/ck-diagnostic.tsx:214
 msgid "Le dossier du jeu est protégé en écriture. Extrayez les archives vous-même, ou installez le jeu hors de Program Files."
 msgstr "Le dossier du jeu est protégé en écriture. Extrayez les archives vous-même, ou installez le jeu hors de Program Files."
 
 #: src/renderer/components/ck-diagnostic.tsx:84
 msgid "Le jeu est introuvable"
 msgstr "Le jeu est introuvable"
+
+#: src/renderer/pages/compilation/compilation-page.tsx:201
+msgid "Le script extender est installé sans ses scripts sources."
+msgstr "Le script extender est installé sans ses scripts sources."
 
 #: src/renderer/components/app-sidebar.tsx:52
 msgid "Logs"
@@ -364,7 +389,8 @@ msgstr "Nouvelle version disponible : {latestVersion}"
 msgid "Où est installé {0} ?"
 msgstr "Où est installé {0} ?"
 
-#: src/renderer/components/ck-diagnostic.tsx:268
+#: src/renderer/components/ck-diagnostic.tsx:269
+#: src/renderer/components/ck-diagnostic.tsx:447
 msgid "Ouvrir le dossier"
 msgstr "Ouvrir le dossier"
 
@@ -385,7 +411,7 @@ msgid "Parcourir"
 msgstr "Parcourir"
 
 #. placeholder {0}: toCompilerSourceFile(game.type)
-#: src/renderer/components/ck-diagnostic.tsx:385
+#: src/renderer/components/ck-diagnostic.tsx:386
 msgid "PCA cherche le fichier {0} dans les dossiers Scripts\\Source ou Source\\Scripts du dossier Data du jeu pour valider l'installation du Creation Kit."
 msgstr "PCA cherche le fichier {0} dans les dossiers Scripts\\Source ou Source\\Scripts du dossier Data du jeu pour valider l'installation du Creation Kit."
 
@@ -402,13 +428,13 @@ msgstr "PCA compile les scripts Papyrus de ce jeu. Vous pourrez en changer à to
 #. placeholder {0}: game.type
 #. placeholder {1}: compilation.compilerPath
 #. placeholder {2}: item.game
-#: src/renderer/components/ck-diagnostic.tsx:349
+#: src/renderer/components/ck-diagnostic.tsx:350
 msgid "PCA compilerait du {0} avec \"{1}\", qui appartient à {2}. Ces compilateurs ne sont pas interchangeables. Si vous venez de changer de jeu, c'est un reste du précédent."
 msgstr "PCA compilerait du {0} avec \"{1}\", qui appartient à {2}. Ces compilateurs ne sont pas interchangeables. Si vous venez de changer de jeu, c'est un reste du précédent."
 
 #. placeholder {0}: game.type
 #. placeholder {1}: ck.name
-#: src/renderer/components/ck-diagnostic.tsx:124
+#: src/renderer/components/ck-diagnostic.tsx:125
 msgid "PCA n'a trouvé aucun script source de {0}. Le Creation Kit s'installe gratuitement depuis Steam, en cherchant \"{1}\", et dépose ces scripts dans le dossier du jeu."
 msgstr "PCA n'a trouvé aucun script source de {0}. Le Creation Kit s'installe gratuitement depuis Steam, en cherchant \"{1}\", et dépose ces scripts dans le dossier du jeu."
 
@@ -417,12 +443,21 @@ msgstr "PCA n'a trouvé aucun script source de {0}. Le Creation Kit s'installe g
 #~ msgid "PCA n'a trouvé ni le compilateur Papyrus, ni les scripts sources du jeu. Le Creation Kit s'installe gratuitement depuis Steam, en cherchant \"{0}\"."
 #~ msgstr "PCA n'a trouvé ni le compilateur Papyrus, ni les scripts sources du jeu. Le Creation Kit s'installe gratuitement depuis Steam, en cherchant \"{0}\"."
 
-#: src/renderer/components/ck-diagnostic.tsx:243
+#: src/renderer/components/ck-diagnostic.tsx:244
 msgid "PCA ne sait pas ouvrir une archive .rar : extrayez-la vous-même avec 7-Zip ou WinRAR, en conservant les dossiers."
 msgstr "PCA ne sait pas ouvrir une archive .rar : extrayez-la vous-même avec 7-Zip ou WinRAR, en conservant les dossiers."
 
+#. placeholder {0}: game.type
+#: src/renderer/components/ck-diagnostic.tsx:427
+msgid "PCA, lui, l'importe avant Data\\Source\\Scripts : une ancienne copie des scripts du jeu qui y traîne masque celle de {0}, et la compilation échoue sans raison apparente."
+msgstr "PCA, lui, l'importe avant Data\\Source\\Scripts : une ancienne copie des scripts du jeu qui y traîne masque celle de {0}, et la compilation échoue sans raison apparente."
+
+#: src/renderer/components/ck-diagnostic.tsx:425
+#~ msgid "PCA, lui, l'importe avant Data\\Source\\Scripts : une ancienne copie des scripts du jeu qui y traîne masque celle de Special Edition, et la compilation échoue sans raison apparente."
+#~ msgstr "PCA, lui, l'importe avant Data\\Source\\Scripts : une ancienne copie des scripts du jeu qui y traîne masque celle de Special Edition, et la compilation échoue sans raison apparente."
+
 #: src/renderer/components/dialog/dialog-recent-files.tsx:276
-#: src/renderer/pages/compilation/compilation-page.tsx:210
+#: src/renderer/pages/compilation/compilation-page.tsx:220
 #: src/renderer/pages/groups/groups-page.tsx:118
 msgid "Plus de détails"
 msgstr "Plus de détails"
@@ -456,11 +491,11 @@ msgstr "Retirer"
 msgid "Retour"
 msgstr "Retour"
 
-#: src/renderer/components/ck-diagnostic.tsx:381
+#: src/renderer/components/ck-diagnostic.tsx:382
 msgid "Scripts sources introuvables"
 msgstr "Scripts sources introuvables"
 
-#: src/renderer/components/ck-diagnostic.tsx:225
+#: src/renderer/components/ck-diagnostic.tsx:226
 msgid "Scripts sources non extraits"
 msgstr "Scripts sources non extraits"
 
@@ -482,9 +517,13 @@ msgid "Sélectionner votre jeu"
 msgstr "Sélectionner votre jeu"
 
 #. placeholder {0}: game.type
-#: src/renderer/components/ck-diagnostic.tsx:140
+#: src/renderer/components/ck-diagnostic.tsx:141
 msgid "Si vous avez déjà un PapyrusCompiler.exe ailleurs, vous pouvez le désigner : celui de Skyrim Special Edition compile aussi bien pour Skyrim VR. Les scripts sources, eux, doivent se trouver dans le dossier de {0}."
 msgstr "Si vous avez déjà un PapyrusCompiler.exe ailleurs, vous pouvez le désigner : celui de Skyrim Special Edition compile aussi bien pour Skyrim VR. Les scripts sources, eux, doivent se trouver dans le dossier de {0}."
+
+#: src/renderer/components/ck-diagnostic.tsx:417
+#~ msgid "Skyrim Special Edition range ses scripts sources dans Data\\Source\\Scripts, et le Creation Kit ne lit que ce dossier. Data\\Scripts\\Source est celui de Skyrim LE : tout ce qui y reste lui est invisible."
+#~ msgstr "Skyrim Special Edition range ses scripts sources dans Data\\Source\\Scripts, et le Creation Kit ne lit que ce dossier. Data\\Scripts\\Source est celui de Skyrim LE : tout ce qui y reste lui est invisible."
 
 #: src/renderer/pages/settings/settings-preferences-section.tsx:57
 #: src/renderer/pages/settings/settings-theme-section.tsx:50
@@ -513,7 +552,7 @@ msgid "Télécharger"
 msgstr "Télécharger"
 
 #. placeholder {0}: extender.name
-#: src/renderer/components/ck-diagnostic.tsx:433
+#: src/renderer/components/ck-diagnostic.tsx:493
 msgid "Télécharger {0}"
 msgstr "Télécharger {0}"
 
@@ -534,7 +573,7 @@ msgstr "Tous les fichiers récents sont déjà chargés."
 msgid "Tout est prêt. Glissez vos fichiers .psc dans la page Compilation, ou utilisez le bouton d'ajout."
 msgstr "Tout est prêt. Glissez vos fichiers .psc dans la page Compilation, ou utilisez le bouton d'ajout."
 
-#: src/renderer/components/ck-diagnostic.tsx:257
+#: src/renderer/components/ck-diagnostic.tsx:258
 msgid "Tout extraire"
 msgstr "Tout extraire"
 
@@ -543,7 +582,7 @@ msgid "Un groupe est un ensemble de scripts qui peut être ajoutés rapidement �
 msgstr "Un groupe est un ensemble de scripts qui peut être ajoutés rapidement à la compilation."
 
 #. placeholder {0}: game.type
-#: src/renderer/components/ck-diagnostic.tsx:362
+#: src/renderer/components/ck-diagnostic.tsx:363
 msgid "Utiliser celui de {0}"
 msgstr "Utiliser celui de {0}"
 
@@ -551,15 +590,15 @@ msgstr "Utiliser celui de {0}"
 msgid "Vérifier à nouveau"
 msgstr "Vérifier à nouveau"
 
-#: src/renderer/pages/compilation/compilation-page.tsx:193
+#: src/renderer/pages/compilation/compilation-page.tsx:197
 msgid "Vérifiez l'installation de Creation Kit."
 msgstr "Vérifiez l'installation de Creation Kit."
 
-#: src/renderer/pages/compilation/compilation-page.tsx:192
+#: src/renderer/pages/compilation/compilation-page.tsx:196
 msgid "Vérifiez le chemin du compilateur."
 msgstr "Vérifiez le chemin du compilateur."
 
-#: src/renderer/pages/compilation/compilation-page.tsx:189
+#: src/renderer/pages/compilation/compilation-page.tsx:193
 msgid "Vérifiez le chemin du jeu."
 msgstr "Vérifiez le chemin du jeu."
 
@@ -590,15 +629,16 @@ msgstr "Version"
 msgid "Vider"
 msgstr "Vider"
 
-#: src/renderer/pages/compilation/compilation-page.tsx:300
+#: src/renderer/pages/compilation/compilation-page.tsx:311
 msgid "Vider la liste"
 msgstr "Vider la liste"
 
-#: src/renderer/components/ck-diagnostic.tsx:397
+#: src/renderer/components/ck-diagnostic.tsx:398
+#: src/renderer/components/ck-diagnostic.tsx:456
 msgid "Voir la documentation"
 msgstr "Voir la documentation"
 
-#: src/renderer/components/ck-diagnostic.tsx:170
+#: src/renderer/components/ck-diagnostic.tsx:171
 msgid "Voir sur le magasin Steam"
 msgstr "Voir sur le magasin Steam"
 

--- a/src/renderer/pages/compilation/compilation-page.tsx
+++ b/src/renderer/pages/compilation/compilation-page.tsx
@@ -181,38 +181,49 @@ export function CompilationPage() {
 
   useEffect(() => {
     let toastId = undefined as string | number | undefined
-    const error = diagnostic.items.find((item) => item.severity === 'error')
+    // an error stops the compilation, a warning only threatens it: the first
+    // error has everything to say, and a warning under it would be noise
+    const issue =
+      diagnostic.items.find((item) => item.severity === 'error') ??
+      diagnostic.items.find((item) => item.severity === 'warning')
 
     // the setup wizard already shows the very same diagnostic, in place
-    if (error !== undefined && !isSetupOpen) {
+    if (issue !== undefined && !isSetupOpen) {
       const descriptions: Record<DiagnosticId, string> = {
         'game-exe': t`Vérifiez le chemin du jeu.`,
         'ck-missing': t`Le Creation Kit n'est pas installé.`,
         'sources-archived': t`Des archives de scripts sources restent à extraire.`,
         compiler: t`Vérifiez le chemin du compilateur.`,
         'sources-missing': t`Vérifiez l'installation de Creation Kit.`,
-        // warnings never reach this map, the toast only shows errors
+        'sources-legacy': t`Des scripts sources sont dans Scripts\\Source au lieu de Source\\Scripts.`,
+        // the title already names the game the compiler belongs to
         'compiler-foreign': '',
-        'extender-sources': '',
+        'extender-sources': t`Le script extender est installé sans ses scripts sources.`,
       }
-      toastId = toast.error(t`Configuration invalide`, {
-        // the toaster lives in its own portal, outside the router: a Link
-        // rendered in there has no router to read from
-        action: (
-          <Button
-            variant="link"
-            size="sm"
-            onClick={() => {
-              toast.dismiss(toastId)
-              void navigate({ to: '/settings' })
-            }}
-          >
-            <Trans>Plus de détails</Trans>
-          </Button>
-        ),
-        description: descriptions[error.id],
-        duration: Infinity,
-      })
+      const notify = issue.severity === 'error' ? toast.error : toast.warning
+      toastId = notify(
+        issue.severity === 'error'
+          ? t`Configuration invalide`
+          : t`La compilation peut échouer`,
+        {
+          // the toaster lives in its own portal, outside the router: a Link
+          // rendered in there has no router to read from
+          action: (
+            <Button
+              variant="link"
+              size="sm"
+              onClick={() => {
+                toast.dismiss(toastId)
+                void navigate({ to: '/settings' })
+              }}
+            >
+              <Trans>Plus de détails</Trans>
+            </Button>
+          ),
+          description: descriptions[issue.id],
+          duration: Infinity,
+        },
+      )
     }
 
     return () => {

--- a/var/SkyrimSE/Data/Source/Scripts/Actor.psc
+++ b/var/SkyrimSE/Data/Source/Scripts/Actor.psc
@@ -1,5 +1,0 @@
-Scriptname Actor extends Quest
-
-Function test()
-
-EndFunction

--- a/var/SkyrimSE/Data/Source/Scripts/Data.psc
+++ b/var/SkyrimSE/Data/Source/Scripts/Data.psc
@@ -1,5 +1,0 @@
-Scriptname Data extends Quest
-
-Function test()
-
-EndFunction


### PR DESCRIPTION
## Issues

Closes #173

## Description

Skyrim SE and VR read their source scripts from `Data\Source\Scripts`, and their Creation Kit reads that folder only. Anything left in `Data\Scripts\Source`, the Skyrim LE layout, is invisible to the kit, and PCA imports that folder *before* the game one: an outdated copy of the game scripts left in there shadows the one the game ships, and the compilation fails for no apparent reason.

A new non blocking `sources-legacy` diagnostic reports it when the LE folder holds at least one `.psc` right inside it. The alert explains the shadowing, recommends moving everything to `Data\Source\Scripts`, and opens the folder.

The guard is the layout itself, `toSource(gameType) === GameSource.sourceFirst`, so it covers SE and VR and will follow any game that adopts `Source\Scripts`.

## Notes

The Compilation page used to toast errors only, so a warning was visible in the settings and in the setup wizard but nowhere else. It now toasts the first warning when there is no error, which also surfaces `extender-sources` for the first time. That part goes slightly beyond the issue.

The scan is not recursive: only the `.psc` sitting right inside the folder count, since an import root is handed to the compiler as is and it never walks into subfolders.

Also drops `var/SkyrimSE/Data/Source/Scripts/Actor.psc` and `Data.psc`. They were empty overrides of base game scripts and broke every compilation run against that fixture.
