### PR TITLE
feat(compilation): anonymize the pex header

### DIFF
--- a/.changeset/0028-pex-anonymization.md
+++ b/.changeset/0028-pex-anonymization.md
@@ -1,0 +1,7 @@
+---
+'pca': minor
+---
+
+Anonymization of the compiled scripts, on by default and switchable off in the compilation settings. The compiler writes the path of the source script, the user name and the computer name in the pex header, all three readable by anyone who opens the file: PCA now replaces them with random strings of the very same lengths once the compilation succeeded. Nothing else is touched, the compilation time and every byte of the compiled code included, and the pex keeps its size. Skyrim, Fallout 4 and Starfield alike, and whichever compiler PCA is pointed at.
+
+An existing configuration is upgraded with the anonymization on, as a new one is. When it fails, the compilation stays a success, the script is compiled after all, and the reason is raised in its log.

--- a/src/common/types/config.ts
+++ b/src/common/types/config.ts
@@ -23,6 +23,8 @@ interface Compilation {
   compilerPath: CompilerPath
   flag: Flag
   output: OutputPath
+  /** strip the identifying information the compiler writes in the pex header */
+  anonymize: boolean
 }
 
 interface ConfigMo2 {

--- a/src/main/event-handlers/script-compile.event.ts
+++ b/src/main/event-handlers/script-compile.event.ts
@@ -12,6 +12,7 @@ import type { CompilationResult } from '#common/types/compilation-result.ts'
 import { inject } from '#main/inject.ts'
 import { Compiler } from '#main/compilation/compiler.ts'
 import { basename } from '../path/path'
+import { anonymizePex } from '../utils/anonymize-pex.util'
 
 @inject()
 export class ScriptCompileEvent {
@@ -49,6 +50,32 @@ export class ScriptCompileEvent {
     return log.replace(`Script ${script} failed to compile: `, '').trim()
   }
 
+  /**
+   * The pex is anonymized on demand only, and never by the compiler itself: any
+   * compiler PCA is pointed at gets the same treatment. A failure leaves a
+   * script that runs, so the compilation stays a success and the reason is
+   * raised in its log, where the user can see the header was left untouched.
+   */
+  async #anonymize(pexPath: string, output: string): Promise<string> {
+    if (this.#settingsStore.get('compilation.anonymize') !== true) {
+      return output
+    }
+
+    try {
+      await anonymizePex(pexPath)
+
+      return output
+    } catch (e) {
+      const message = fromError(e).message
+
+      this.#logger.error('anonymization failed', message)
+
+      const warning = `Anonymization failed: ${message}`
+
+      return is.emptyString(output) ? warning : `${output}\n${warning}`
+    }
+  }
+
   async run(scriptPath: string): Promise<CompilationResult> {
     if (is.undefined(scriptPath)) {
       throw new ApplicationException('script-compile: script is undefined')
@@ -68,7 +95,10 @@ export class ScriptCompileEvent {
 
       return {
         success: true,
-        output: ScriptCompileEvent._cleanSuccessLog(name, output),
+        output: await this.#anonymize(
+          pexPath,
+          ScriptCompileEvent._cleanSuccessLog(name, output),
+        ),
         script: scriptName,
         pexPath,
       }

--- a/src/main/exceptions/anonymization.exception.ts
+++ b/src/main/exceptions/anonymization.exception.ts
@@ -1,0 +1,9 @@
+/*
+ * 2026 Kiyozz.
+ */
+
+export class AnonymizationException extends Error {
+  constructor(pex: string, reason: string) {
+    super(`Cannot anonymize "${pex}": ${reason}`)
+  }
+}

--- a/src/main/store/settings/store.ts
+++ b/src/main/store/settings/store.ts
@@ -53,6 +53,7 @@ const defaultSettingsStoreConfig: Config = {
     compilerPath: '',
     flag: 'TESV_Papyrus_Flags.flg',
     output: '',
+    anonymize: true,
   },
   mo2: {
     use: false,
@@ -189,6 +190,17 @@ class SettingsStore extends Store<Config> {
     }
   }
 
+  #checkAnonymize() {
+    const anonymize = this.get('compilation.anonymize')
+
+    if (!is.boolean(anonymize)) {
+      this.set(
+        'compilation.anonymize',
+        defaultSettingsStoreConfig.compilation.anonymize,
+      )
+    }
+  }
+
   #checkGroups() {
     const groups = this.get('groups')
 
@@ -289,6 +301,7 @@ class SettingsStore extends Store<Config> {
     this.#checkFlag()
     this.#checkCompilerPath(args)
     this.#checkOutput(args)
+    this.#checkAnonymize()
     this.#checkGroups()
     this.#checkConcurrentScripts()
     this.#checkNotSupportedKeys()

--- a/src/main/utils/anonymize-pex.util.ts
+++ b/src/main/utils/anonymize-pex.util.ts
@@ -1,0 +1,169 @@
+/*
+ * 2026 Kiyozz.
+ */
+
+import { randomInt } from 'node:crypto'
+import { open } from 'node:fs/promises'
+import { AnonymizationException } from '../exceptions/anonymization.exception'
+import { Logger } from '../logger'
+import type { FileHandle } from 'node:fs/promises'
+
+const logger = new Logger('AnonymizePex')
+
+/**
+ * The four magic bytes, read as a little endian integer. Skyrim writes its pex
+ * big endian, Fallout 4 and Starfield little endian: the magic tells which, and
+ * the rest of the header is then read the same way.
+ */
+const MAGIC_LITTLE = 0xfa57c0de
+const MAGIC_BIG = 0xdec057fa
+
+/** magic, versions, game id and compilation time all sit before the strings */
+const HEADER_STRINGS_OFFSET = 4 + 1 + 1 + 2 + 8
+
+interface PexString {
+  /** where the characters start, the size is written just before them */
+  offset: number
+  size: number
+  value: string
+}
+
+interface PexHeader {
+  scriptPath: PexString
+  userName: PexString
+  computerName: PexString
+}
+
+async function readExact(
+  file: FileHandle,
+  pexPath: string,
+  position: number,
+  length: number,
+): Promise<Buffer> {
+  const buffer = Buffer.alloc(length)
+  const { bytesRead } = await file.read(buffer, 0, length, position)
+
+  if (bytesRead !== length) {
+    throw new AnonymizationException(
+      pexPath,
+      `the file ends at ${position + bytesRead}, before its header does`,
+    )
+  }
+
+  return buffer
+}
+
+async function readHeader(
+  file: FileHandle,
+  pexPath: string,
+): Promise<PexHeader> {
+  const magic = (await readExact(file, pexPath, 0, 4)).readUInt32LE(0)
+
+  if (magic !== MAGIC_LITTLE && magic !== MAGIC_BIG) {
+    throw new AnonymizationException(
+      pexPath,
+      `unknown file magic 0x${magic.toString(16).toUpperCase()}, this is not a compiled script`,
+    )
+  }
+
+  const bigEndian = magic === MAGIC_BIG
+  let position = HEADER_STRINGS_OFFSET
+
+  const readString = async (): Promise<PexString> => {
+    const sizeBuffer = await readExact(file, pexPath, position, 2)
+    const size = bigEndian
+      ? sizeBuffer.readUInt16BE(0)
+      : sizeBuffer.readUInt16LE(0)
+    const offset = position + 2
+    // the compiler only ever writes ascii there, latin1 never throws on the
+    // bytes a broken file could hold and keeps one character per byte, which
+    // is what the sizes and offsets are counted in
+    const value = (await readExact(file, pexPath, offset, size)).toString(
+      'latin1',
+    )
+
+    position = offset + size
+
+    return { offset, size, value }
+  }
+
+  return {
+    scriptPath: await readString(),
+    userName: await readString(),
+    computerName: await readString(),
+  }
+}
+
+function randomString(size: number, uppercase: boolean): string {
+  const first = uppercase ? 65 : 97
+
+  return Array.from({ length: size }, () =>
+    String.fromCharCode(first + randomInt(26)),
+  ).join('')
+}
+
+async function overwrite(
+  file: FileHandle,
+  { offset, size }: PexString,
+  uppercase: boolean,
+): Promise<void> {
+  // a compiler other than the kit one may leave a field empty: there is nothing
+  // to hide then, and nowhere to write it
+  if (size === 0) {
+    return
+  }
+
+  // the replacement has the exact same length: every offset after it, and the
+  // rest of the file, stay where the compiler put them
+  await file.write(
+    Buffer.from(randomString(size, uppercase), 'ascii'),
+    0,
+    size,
+    offset,
+  )
+}
+
+/**
+ * Replaces the source script path, the user name and the computer name the
+ * compiler writes in the pex header with random strings of the same lengths.
+ * Nothing else is touched, the compilation time included.
+ *
+ * Returns false when the script was already anonymized.
+ */
+export async function anonymizePex(pexPath: string): Promise<boolean> {
+  logger.debug('anonymizing', pexPath)
+
+  const file = await open(pexPath, 'r+')
+
+  try {
+    const header = await readHeader(file, pexPath)
+    const { scriptPath, userName, computerName } = header
+
+    // a path without an extension is a path this function already replaced
+    if (!scriptPath.value.includes('.')) {
+      logger.debug('already anonymized, nothing to do', pexPath)
+
+      return false
+    }
+
+    // the path is the only field whose shape is known: it not being a psc file
+    // means the header was read wrong, and writing at those offsets would
+    // corrupt a compiled script that works
+    if (!scriptPath.value.toLowerCase().endsWith('.psc')) {
+      throw new AnonymizationException(
+        pexPath,
+        `the script path "${scriptPath.value}" is not a psc file`,
+      )
+    }
+
+    await overwrite(file, scriptPath, false)
+    await overwrite(file, userName, false)
+    await overwrite(file, computerName, true)
+
+    logger.info('anonymized', pexPath)
+
+    return true
+  } finally {
+    await file.close()
+  }
+}

--- a/src/renderer/locales/en/messages.po
+++ b/src/renderer/locales/en/messages.po
@@ -49,6 +49,10 @@ msgstr "Enable"
 msgid "Annuler"
 msgstr "Cancel"
 
+#: src/renderer/pages/settings/settings-compilation.tsx:65
+msgid "Anonymiser les scripts compilés"
+msgstr "Anonymize compiled scripts"
+
 #: src/renderer/components/ck-diagnostic.tsx:207
 msgid "Archives extraites"
 msgstr "Archives extracted"
@@ -137,7 +141,7 @@ msgstr "Compiler in use"
 
 #: src/renderer/components/app-sidebar.tsx:34
 #: src/renderer/pages/compilation/compilation-page.tsx:242
-#: src/renderer/pages/settings/settings-compilation.tsx:21
+#: src/renderer/pages/settings/settings-compilation.tsx:22
 msgid "Compilation"
 msgstr "Compilation"
 
@@ -186,7 +190,7 @@ msgid "Des scripts sources sont dans Scripts\\Source au lieu de Source\\Scripts.
 msgstr "Source scripts are sitting in Scripts\\Source instead of Source\\Scripts."
 
 #: src/renderer/components/app-sidebar.tsx:57
-#: src/renderer/pages/settings/settings-page.tsx:273
+#: src/renderer/pages/settings/settings-page.tsx:281
 msgid "Documentation"
 msgstr "Documentation"
 
@@ -195,7 +199,7 @@ msgstr "Documentation"
 msgid "Données d'utilisation"
 msgstr "Telemetry"
 
-#: src/renderer/pages/settings/settings-compilation.tsx:48
+#: src/renderer/pages/settings/settings-compilation.tsx:49
 msgid "Dossier de sortie"
 msgstr "Output folder"
 
@@ -296,7 +300,7 @@ msgstr "The compilation may fail"
 #~ msgid "La configuration semble invalide :"
 #~ msgstr "Configuration seems invalid:"
 
-#: src/renderer/pages/settings/settings-compilation.tsx:50
+#: src/renderer/pages/settings/settings-compilation.tsx:51
 msgid "Laissez vide pour utiliser le dossier par défaut du jeu (Data/Scripts)."
 msgstr "Leave empty to use the default game folder (Data/Scripts)."
 
@@ -368,7 +372,7 @@ msgstr "Log level"
 msgid "Nom"
 msgstr "Name"
 
-#: src/renderer/pages/settings/settings-compilation.tsx:30
+#: src/renderer/pages/settings/settings-compilation.tsx:31
 msgid "Nombre de scripts compilés simultanéments"
 msgstr "Number of concurrently compiled scripts"
 
@@ -402,7 +406,7 @@ msgid "Ouvrir le dossier du script compilé"
 msgstr "Open the compiled script folder"
 
 #: src/renderer/components/app-sidebar.tsx:44
-#: src/renderer/pages/settings/settings-page.tsx:258
+#: src/renderer/pages/settings/settings-page.tsx:266
 msgid "Paramètres"
 msgstr "Settings"
 
@@ -470,17 +474,21 @@ msgstr "Preferences"
 msgid "Quel jeu voulez-vous modder ?"
 msgstr "Which game do you want to mod?"
 
-#: src/renderer/pages/settings/settings-page.tsx:283
+#: src/renderer/pages/settings/settings-page.tsx:291
 msgid "Rafraîchir"
 msgstr "Refresh"
 
-#: src/renderer/pages/settings/settings-compilation.tsx:36
+#: src/renderer/pages/settings/settings-compilation.tsx:37
 msgid "Réduisez si vous rencontrez des blocages quand vous lancez la compilation"
 msgstr "Reduce if you experience latency when starting the compilation"
 
 #: src/renderer/pages/settings/settings-about-section.tsx:31
 msgid "Relancer l'assistant de configuration"
 msgstr "Run the setup wizard again"
+
+#: src/renderer/pages/settings/settings-compilation.tsx:75
+msgid "Remplace le chemin du script, votre nom d'utilisateur et le nom de votre ordinateur dans l'en-tête du fichier .pex par des caractères aléatoires."
+msgstr "Replaces the script path, your user name and your computer name in the .pex header with random characters."
 
 #: src/renderer/components/dialog/dialog-group.tsx:158
 #: src/renderer/pages/compilation/script-line.tsx:82

--- a/src/renderer/locales/fr/messages.po
+++ b/src/renderer/locales/fr/messages.po
@@ -49,6 +49,10 @@ msgstr "Activer"
 msgid "Annuler"
 msgstr "Annuler"
 
+#: src/renderer/pages/settings/settings-compilation.tsx:65
+msgid "Anonymiser les scripts compilés"
+msgstr "Anonymiser les scripts compilés"
+
 #: src/renderer/components/ck-diagnostic.tsx:207
 msgid "Archives extraites"
 msgstr "Archives extraites"
@@ -137,7 +141,7 @@ msgstr "Compilateur utilisé"
 
 #: src/renderer/components/app-sidebar.tsx:34
 #: src/renderer/pages/compilation/compilation-page.tsx:242
-#: src/renderer/pages/settings/settings-compilation.tsx:21
+#: src/renderer/pages/settings/settings-compilation.tsx:22
 msgid "Compilation"
 msgstr "Compilation"
 
@@ -186,7 +190,7 @@ msgid "Des scripts sources sont dans Scripts\\Source au lieu de Source\\Scripts.
 msgstr "Des scripts sources sont dans Scripts\\Source au lieu de Source\\Scripts."
 
 #: src/renderer/components/app-sidebar.tsx:57
-#: src/renderer/pages/settings/settings-page.tsx:273
+#: src/renderer/pages/settings/settings-page.tsx:281
 msgid "Documentation"
 msgstr "Documentation"
 
@@ -195,7 +199,7 @@ msgstr "Documentation"
 msgid "Données d'utilisation"
 msgstr "Données d'utilisation"
 
-#: src/renderer/pages/settings/settings-compilation.tsx:48
+#: src/renderer/pages/settings/settings-compilation.tsx:49
 msgid "Dossier de sortie"
 msgstr "Dossier de sortie"
 
@@ -296,7 +300,7 @@ msgstr "La compilation peut échouer"
 #~ msgid "La configuration semble invalide :"
 #~ msgstr "La configuration semble invalide :"
 
-#: src/renderer/pages/settings/settings-compilation.tsx:50
+#: src/renderer/pages/settings/settings-compilation.tsx:51
 msgid "Laissez vide pour utiliser le dossier par défaut du jeu (Data/Scripts)."
 msgstr "Laissez vide pour utiliser le dossier par défaut du jeu (Data/Scripts)."
 
@@ -368,7 +372,7 @@ msgstr "Niveau de log"
 msgid "Nom"
 msgstr "Nom"
 
-#: src/renderer/pages/settings/settings-compilation.tsx:30
+#: src/renderer/pages/settings/settings-compilation.tsx:31
 msgid "Nombre de scripts compilés simultanéments"
 msgstr "Nombre de scripts compilés simultanéments"
 
@@ -402,7 +406,7 @@ msgid "Ouvrir le dossier du script compilé"
 msgstr "Ouvrir le dossier du script compilé"
 
 #: src/renderer/components/app-sidebar.tsx:44
-#: src/renderer/pages/settings/settings-page.tsx:258
+#: src/renderer/pages/settings/settings-page.tsx:266
 msgid "Paramètres"
 msgstr "Paramètres"
 
@@ -470,17 +474,21 @@ msgstr "Préférences"
 msgid "Quel jeu voulez-vous modder ?"
 msgstr "Quel jeu voulez-vous modder ?"
 
-#: src/renderer/pages/settings/settings-page.tsx:283
+#: src/renderer/pages/settings/settings-page.tsx:291
 msgid "Rafraîchir"
 msgstr "Rafraîchir"
 
-#: src/renderer/pages/settings/settings-compilation.tsx:36
+#: src/renderer/pages/settings/settings-compilation.tsx:37
 msgid "Réduisez si vous rencontrez des blocages quand vous lancez la compilation"
 msgstr "Réduisez si vous rencontrez des blocages quand vous lancez la compilation"
 
 #: src/renderer/pages/settings/settings-about-section.tsx:31
 msgid "Relancer l'assistant de configuration"
 msgstr "Relancer l'assistant de configuration"
+
+#: src/renderer/pages/settings/settings-compilation.tsx:75
+msgid "Remplace le chemin du script, votre nom d'utilisateur et le nom de votre ordinateur dans l'en-tête du fichier .pex par des caractères aléatoires."
+msgstr "Remplace le chemin du script, votre nom d'utilisateur et le nom de votre ordinateur dans l'en-tête du fichier .pex par des caractères aléatoires."
 
 #: src/renderer/components/dialog/dialog-group.tsx:158
 #: src/renderer/pages/compilation/script-line.tsx:82

--- a/src/renderer/pages/settings/settings-compilation.tsx
+++ b/src/renderer/pages/settings/settings-compilation.tsx
@@ -12,6 +12,7 @@ import {
   FormLabel,
 } from '@renderer/components/ui/form.tsx'
 import { Input } from '@renderer/components/ui/input.tsx'
+import { Switch } from '@renderer/components/ui/switch.tsx'
 import DialogTextField from '@renderer/components/dialog/dialog-text-field.tsx'
 
 function SettingsCompilation() {
@@ -53,6 +54,32 @@ function SettingsCompilation() {
             </Trans>
           }
           type="folder"
+        />
+
+        <FormField
+          name="anonymize"
+          render={({ field }) => (
+            <FormItem>
+              <div className="flex items-center justify-between">
+                <FormLabel>
+                  <Trans>Anonymiser les scripts compilés</Trans>
+                </FormLabel>
+                <FormControl>
+                  <Switch
+                    checked={field.value}
+                    onCheckedChange={field.onChange}
+                  />
+                </FormControl>
+              </div>
+              <FormDescription>
+                <Trans>
+                  Remplace le chemin du script, votre nom d'utilisateur et le
+                  nom de votre ordinateur dans l'en-tête du fichier .pex par des
+                  caractères aléatoires.
+                </Trans>
+              </FormDescription>
+            </FormItem>
+          )}
         />
       </SettingsSectionContent>
     </SettingsSection>

--- a/src/renderer/pages/settings/settings-page.tsx
+++ b/src/renderer/pages/settings/settings-page.tsx
@@ -68,6 +68,7 @@ export function SettingsPage() {
       compilerPath: compilation.compilerPath,
       concurrentScripts: compilation.concurrentScripts,
       output: compilation.output,
+      anonymize: compilation.anonymize,
       mo2: mo2.use,
       telemetry,
       theme,
@@ -221,6 +222,13 @@ export function SettingsPage() {
 
             debouncedSetConfig({
               compilation: { output: output.trim() },
+            })
+
+            break
+          }
+          case 'anonymize': {
+            setConfig({
+              compilation: { anonymize: value.anonymize === true },
             })
 
             break


### PR DESCRIPTION
## Issues

Closes #145

## Description

The Papyrus compiler writes the path of the source script, the user name and the computer name in the header of every pex it produces, where anyone who opens the file can read them. PCA now replaces the three with random strings of the exact same lengths once a script has compiled, the way Pyro does it: nothing is truncated, nothing is removed, and every other byte of the file stays where the compiler put it, the compilation time and the compiled code included.

The setting lives in the compilation settings and is on by default, for existing configurations as for new ones.

## Notes

- The anonymization runs in `ScriptCompileEvent`, not in `PapyrusCompilerService`: the `Compiler` stays a compiler, and whichever compiler PCA is pointed at gets the same treatment.
- The endianness comes from the file magic, so Skyrim LE/SE/VR (big endian) and Fallout 4/Starfield (little endian) are all handled without asking the settings which game this is.
- The script path is checked to be a psc file before anything is written: a path that is not one means the header was read wrong, and writing at those offsets would corrupt a working script.
- A failure leaves a compiled script that runs, so the compilation stays a success and the reason is raised in its log.
- Checked against real compiled scripts, byte for byte: only the three strings change, the sizes and the whole body are identical. Worth knowing, the Starfield compiler already writes `<SUPPRESSED>` for the user and computer names, only the script path leaks there.
