### PR TITLE
ci: run on pull_request, drop path filters

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,15 +1,13 @@
 name: CI
 
+# `ci` is a required status check on main: every pull request has to produce a
+# run, so no path filters here. A docs-only or locales-only PR would otherwise
+# never get the check and stay unmergeable.
 on:
   push:
-    paths:
-      - '**.ts'
-      - '**.js'
-      - '**.mjs'
-      - '**.tsx'
-      - '**.json'
-      - '**.yml'
-      - '**.yaml'
+    branches:
+      - main
+  pull_request:
 
 jobs:
   ci:


### PR DESCRIPTION
`ci` is now a required status check on `main` (ruleset `Default`), so every pull request has to produce a run.

With the previous path filters (`**.ts`, `**.tsx`, `**.json`, `**.yml`…), a pull request touching only `.md` files (a lone changeset) or only `.po` files (translations) triggered no workflow at all: the required check would stay pending forever and the pull request would be unmergeable, with no way around it (`bypass_actors` is empty).

- `pull_request` with no path filter: every pull request produces a run.
- `push` limited to `main`: avoids a duplicate run on pull request branches while keeping the signal after merge.