### PR TITLE
ci: upload releases to the NexusMods pages

### DIFF
--- a/.changeset/0032-nexusmods-upload.md
+++ b/.changeset/0032-nexusmods-upload.md
@@ -1,0 +1,5 @@
+---
+'pca': patch
+---
+
+CI: upload every release to the NexusMods pages (Skyrim LE, Skyrim SE, Fallout 4, Starfield) with `Nexus-Mods/upload-action`, changelog included, then publish the GitHub release that stays a draft until the archive is there. The `mod_id`/`file_id` pair of a page comes from repository variables, an unset pair skips it, and `scripts/nexus-ids.mjs` resolves them.

--- a/.github/workflows/nexus-test.yml
+++ b/.github/workflows/nexus-test.yml
@@ -1,0 +1,48 @@
+name: NexusMods upload test
+
+# The upload action has no dry run, so this is the smoke test for it: point it
+# at a mod page of your own left unpublished and look at what lands on it. It
+# uploads a dummy archive and touches no release, no tag and no real page.
+#
+# Ids come from `scripts/nexus-ids.mjs <game-domain>/<id-in-url>`, the page needs
+# a first file uploaded by hand, and the run needs the PCA_NEXUSMODS_API_KEY
+# secret the release workflow uses.
+on:
+  workflow_dispatch:
+    inputs:
+      mod_id:
+        description: mod_id of the test page
+        required: true
+      file_id:
+        description: file_id of the test page
+        required: true
+      version:
+        description: Version to upload as
+        required: true
+        default: '0.0.1'
+
+permissions: {}
+
+jobs:
+  upload:
+    name: Upload a dummy archive
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Build the archive
+        run: |
+          echo 'PCA NexusMods upload test, nothing to see here.' > README.txt
+          7z a PCA.7z README.txt
+
+      - name: Upload to NexusMods
+        uses: Nexus-Mods/upload-action@v1.0.0-beta.10
+        with:
+          api_key: ${{ secrets.PCA_NEXUSMODS_API_KEY }}
+          mod_id: ${{ inputs.mod_id }}
+          file_id: ${{ inputs.file_id }}
+          filename: PCA.7z
+          display_name: PCA ${{ inputs.version }}
+          version: ${{ inputs.version }}
+          changelog: |
+            Test upload, ignore.
+          update_mod_version: false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -72,8 +72,15 @@ jobs:
     if: needs.release.outputs.published == 'true'
     runs-on: windows-latest
 
+    outputs:
+      changelog: ${{ steps.notes.outputs.changelog }}
+
     # Job level: tsdown and vite inline these during `pnpm build`; `pnpm package`
     # only zips the assets `pnpm build` produced.
+    #
+    # PCA_MOD_URL points at the SE page for every copy of the archive, the ones
+    # uploaded to the other game pages included: it is the page the in-app
+    # update notice sends users to, and the SE one is where PCA lives.
     env:
       PCA_MOD_URL: https://www.nexusmods.com/skyrimspecialedition/mods/23852?tab=files
       PCA_TELEMETRY_ENABLED: 'true'
@@ -99,15 +106,24 @@ jobs:
       - name: Package
         run: pnpm package
 
+      # Also exposed as a job output, for the NexusMods changelog below.
       - name: Extract release notes
+        id: notes
         shell: bash
-        run: >-
-          node scripts/extract-changelog.mjs '${{ needs.release.outputs.version }}'
-          > release-notes.md
+        run: |
+          version='${{ needs.release.outputs.version }}'
+          node scripts/extract-changelog.mjs "$version" > release-notes.md
+          delimiter="notes-$RANDOM$RANDOM"
+          {
+            echo "changelog<<$delimiter"
+            cat release-notes.md
+            echo "$delimiter"
+          } >> "$GITHUB_OUTPUT"
 
-      # TODO: drop --draft once the NexusMods upload step below is in place.
-      # The app polls /releases?per_page=1 unauthenticated, which hides drafts,
-      # so nothing is announced in-app until the release is published by hand.
+      # Drafted here, published by the `publish` job once NexusMods has the
+      # archive. The app polls /releases?per_page=1 unauthenticated, which hides
+      # drafts, so nothing is announced in-app before the download the notice
+      # points at exists.
       - name: Draft GitHub release
         shell: bash
         env:
@@ -119,23 +135,83 @@ jobs:
             --draft \
             'dist/PCA.7z'
 
-      # TODO: upload to NexusMods with Nexus-Mods/upload-action (v3 API, still
-      # in beta). The mod is skyrimspecialedition/mods/23852.
-      #
-      # Two ids are still missing:
-      #   - file_id: the file to add a version to, from "API Info" in the Files
-      #     tab of the mod page.
-      #   - mod_id: NOT the 23852 from the URL (that is the game-scoped id).
-      #     Resolve it once via GET /v3/games/skyrimspecialedition/mods/23852.
-      # Also needs a PCA_NEXUSMODS_API_KEY secret.
-      #
-      # - name: Upload to NexusMods
-      #   uses: Nexus-Mods/upload-action@v1.0.0-beta.10
-      #   with:
-      #     api_key: ${{ secrets.PCA_NEXUSMODS_API_KEY }}
-      #     file_id: <file id, see above>
-      #     mod_id: <mod id, see above>
-      #     filename: dist/PCA.7z
-      #     version: ${{ needs.release.outputs.public-version }}
-      #     changelog: <contents of release-notes.md>
-      #     update_mod_version: true
+      - name: Upload archive
+        uses: actions/upload-artifact@v7
+        with:
+          name: release
+          path: dist/PCA.7z
+
+  nexusmods:
+    name: NexusMods (${{ matrix.game }})
+    needs: [release, package]
+    runs-on: ubuntu-latest
+
+    strategy:
+      # Pages are independent: a rejected upload must not cancel the others. The
+      # job still fails, so the release below stays a draft.
+      fail-fast: false
+      matrix:
+        # Ids live in repository variables rather than here, so that a page can
+        # be wired up (or a remade one fixed) without a commit. They are public
+        # either way: "API Info" in the Files tab of a mod page shows them.
+        # `scripts/nexus-ids.mjs <game-domain>/<id-in-url>` resolves a pair.
+        #
+        # They go by pair. No variable at all skips the page, which is how a
+        # page that does not exist yet is handled; a half-filled pair fails, on
+        # purpose, since the action needs `mod_id` to post the changelog.
+        include:
+          # https://www.nexusmods.com/skyrim/mods/96339
+          - game: Skyrim LE
+            mod_id: ${{ vars.PCA_NEXUS_LE_MOD_ID }}
+            file_id: ${{ vars.PCA_NEXUS_LE_FILE_ID }}
+          # https://www.nexusmods.com/skyrimspecialedition/mods/23852
+          # Also the VR page: PCA has no SkyrimVR one, VR users take this file.
+          - game: Skyrim SE
+            mod_id: ${{ vars.PCA_NEXUS_SE_MOD_ID }}
+            file_id: ${{ vars.PCA_NEXUS_SE_FILE_ID }}
+          - game: Fallout 4
+            mod_id: ${{ vars.PCA_NEXUS_FO4_MOD_ID }}
+            file_id: ${{ vars.PCA_NEXUS_FO4_FILE_ID }}
+          - game: Starfield
+            mod_id: ${{ vars.PCA_NEXUS_SF_MOD_ID }}
+            file_id: ${{ vars.PCA_NEXUS_SF_FILE_ID }}
+
+    steps:
+      - uses: actions/download-artifact@v8
+        if: matrix.file_id != ''
+        with:
+          name: release
+
+      # Adds a version to the existing file, `file_id`. The action never creates
+      # a file, so the first one of a page is uploaded by hand. With
+      # update_mod_version the page then shows the public version (2026.1
+      # style), the number the GitHub release is titled with too.
+      - name: Upload to NexusMods
+        if: matrix.file_id != ''
+        uses: Nexus-Mods/upload-action@v1.0.0-beta.10
+        with:
+          api_key: ${{ secrets.PCA_NEXUSMODS_API_KEY }}
+          mod_id: ${{ matrix.mod_id }}
+          file_id: ${{ matrix.file_id }}
+          filename: PCA.7z
+          display_name: PCA ${{ needs.release.outputs.public-version }}
+          version: ${{ needs.release.outputs.public-version }}
+          changelog: ${{ needs.package.outputs.changelog }}
+          update_mod_version: true
+
+  publish:
+    name: Publish release
+    needs: [release, nexusmods]
+    # The SE page is the one the in-app update notice sends users to: until it
+    # is configured, the release stays a draft and nothing is announced.
+    if: vars.PCA_NEXUS_SE_FILE_ID != ''
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Undraft GitHub release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: >-
+          gh release edit 'v${{ needs.release.outputs.version }}'
+          --repo '${{ github.repository }}'
+          --draft=false

--- a/scripts/nexus-ids.mjs
+++ b/scripts/nexus-ids.mjs
@@ -1,0 +1,70 @@
+// Prints the NexusMods ids the `nexusmods` job of .github/workflows/release.yml
+// needs, for the mod pages given as arguments:
+//
+//   NEXUSMODS_API_KEY=... node scripts/nexus-ids.mjs skyrimspecialedition/23852
+//
+// Neither id is readable from the mod page URL: the number in there is the
+// game-scoped id, while the v3 API wants its own `mod_id`, and `file_id` (the
+// persistent file a new version is added to) only shows up under "API Info" in
+// the Files tab. The key is a personal one, from
+// https://www.nexusmods.com/settings/api-keys.
+const apiKey = process.env.NEXUSMODS_API_KEY
+const pages = process.argv.slice(2)
+
+if (!apiKey || pages.length === 0) {
+  console.error(
+    'usage: NEXUSMODS_API_KEY=<key> node scripts/nexus-ids.mjs <game-domain>/<id-in-url>...',
+  )
+  process.exit(1)
+}
+
+const api = async (path) => {
+  const response = await fetch(`https://api.nexusmods.com/v3${path}`, {
+    headers: {
+      apikey: apiKey,
+      'User-Agent': 'papyrus-compiler-app/nexus-ids',
+    },
+  })
+
+  if (!response.ok) {
+    throw new Error(`GET ${path}: ${response.status} ${await response.text()}`)
+  }
+
+  return (await response.json()).data
+}
+
+try {
+  for (const page of pages) {
+    const [domain, gameScopedId] = page.split('/')
+
+    if (!domain || !gameScopedId) {
+      console.error(`skipping "${page}": expected <game-domain>/<id-in-url>`)
+      continue
+    }
+
+    const { id: modId, name } = await api(
+      `/games/${domain}/mods/${gameScopedId}`,
+    )
+    const { mod_files: files } = await api(`/mods/${modId}/files`)
+
+    console.log(
+      `\n${name ?? '?'} — https://www.nexusmods.com/${domain}/mods/${gameScopedId}`,
+    )
+    console.log(`  mod_id: ${modId}`)
+
+    if (files.length === 0) {
+      console.log(
+        '  no file yet: upload one by hand, the action only adds versions to an existing file',
+      )
+    }
+
+    for (const file of files) {
+      console.log(
+        `  file_id: ${file.id} # ${file.name}${file.is_active ? '' : ' (inactive)'}`,
+      )
+    }
+  }
+} catch (error) {
+  console.error(error.message)
+  process.exit(1)
+}

--- a/scripts/nexus-ids.mjs
+++ b/scripts/nexus-ids.mjs
@@ -1,19 +1,19 @@
 // Prints the NexusMods ids the `nexusmods` job of .github/workflows/release.yml
 // needs, for the mod pages given as arguments:
 //
-//   NEXUSMODS_API_KEY=... node scripts/nexus-ids.mjs skyrimspecialedition/23852
+//   PCA_NEXUSMODS_API_KEY=... node scripts/nexus-ids.mjs skyrimspecialedition/23852
 //
 // Neither id is readable from the mod page URL: the number in there is the
 // game-scoped id, while the v3 API wants its own `mod_id`, and `file_id` (the
 // persistent file a new version is added to) only shows up under "API Info" in
 // the Files tab. The key is a personal one, from
 // https://www.nexusmods.com/settings/api-keys.
-const apiKey = process.env.NEXUSMODS_API_KEY
+const apiKey = process.env.PCA_NEXUSMODS_API_KEY
 const pages = process.argv.slice(2)
 
 if (!apiKey || pages.length === 0) {
   console.error(
-    'usage: NEXUSMODS_API_KEY=<key> node scripts/nexus-ids.mjs <game-domain>/<id-in-url>...',
+    'usage: PCA_NEXUSMODS_API_KEY=<key> node scripts/nexus-ids.mjs <game-domain>/<id-in-url>...',
   )
   process.exit(1)
 }


### PR DESCRIPTION
## Description

Upload every release to the NexusMods mod pages, then publish the GitHub release that was drafted until then.

`package` now exposes the CHANGELOG section as a job output and uploads `PCA.7z` as an artifact. A new `nexusmods` job adds a version to the file of each page with `Nexus-Mods/upload-action`, changelog included, and a `publish` job undrafts the GitHub release once they went through. The archive is the same for every page: `PCA_MOD_URL` keeps pointing at the SE page, the one the in-app update notice sends users to.

Pages: Skyrim LE, Skyrim SE (VR users take this file too, PCA has no SkyrimVR page), Fallout 4 and Starfield.

## Notes

- Needs the `PCA_NEXUSMODS_API_KEY` secret and, per page, the `PCA_NEXUS_{LE,SE,FO4,SF}_{MOD,FILE}_ID` repository variables. `vars` is the only context usable in `strategy.matrix`, and a page whose variables are missing is skipped rather than failing the release.
- `mod_id` is not the number in the page URL (that one is the game-scoped id): `scripts/nexus-ids.mjs <game-domain>/<id-in-url>` resolves both ids through the v3 API.
- The action only adds a version to an existing file, it never creates one, so each page needs a first upload by hand.
- `.github/workflows/nexus-test.yml` is a manual smoke test: the action has no dry run, so it uploads a dummy archive to a mod page given as input, meant for an unpublished one.
- `archive_existing_version` left at its default (`false`); the file is named `PCA <public version>`, matching the current `PCA 2022.1` on NexusMods.
