### PR TITLE
ci: detect releases through changesets/action v2

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,33 +38,34 @@ jobs:
       - run: pnpm install --frozen-lockfile
 
       # Pending changesets -> open/refresh the bot version PR.
-      # None left (PR merged) -> `changeset tag` creates vX.Y.Z locally.
+      # None left (PR merged) -> `changeset git-tag` creates vX.Y.Z and the
+      # action pushes it.
       #
-      # createGithubReleases stays off because the action can only create a
+      # v2 or newer: v1 detected the release by grepping `New tag:` out of the
+      # publish script's stdout, which the Changesets v3 CLI no longer prints,
+      # so `published` came back false and every job below was skipped. v2 reads
+      # the report the CLI writes to `CHANGESETS_OUTPUT` instead.
+      #
+      # create-github-releases stays off because the action can only create a
       # published release, and we want a draft until the NexusMods upload runs.
-      # It also owns the tag push, so we do that ourselves below.
+      # push-git-tags, which it otherwise implies, is what the jobs below need.
       - name: Version pull request or tag
         id: changesets
-        uses: changesets/action@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        uses: changesets/action@v2
         with:
-          version: pnpm changeset:version
-          publish: pnpm changeset:tag
-          commit: 'chore(release): version packages'
-          title: 'chore(release): version packages'
-          createGithubReleases: false
+          version-script: pnpm changeset:version
+          publish-script: pnpm changeset:tag
+          commit-message: 'chore(release): version packages'
+          pr-title: 'chore(release): version packages'
+          create-github-releases: false
+          push-git-tags: true
 
       - name: Read released version
         id: version
         if: steps.changesets.outputs.published == 'true'
         run: |
-          echo "version=${{ fromJson(steps.changesets.outputs.publishedPackages)[0].version }}" >> "$GITHUB_OUTPUT"
+          echo "version=${{ fromJson(steps.changesets.outputs['published-packages'])[0].version }}" >> "$GITHUB_OUTPUT"
           echo "public-version=$(node -p 'require("./package.json").publicVersion')" >> "$GITHUB_OUTPUT"
-
-      - name: Push tag
-        if: steps.changesets.outputs.published == 'true'
-        run: git push origin 'v${{ steps.version.outputs.version }}'
 
   package:
     name: Package

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "lingui:extract:main": "lingui extract --config ./lingui.main.config.ts",
     "lingui:compile:main": "lingui compile --config ./lingui.main.config.ts",
     "changeset:version": "changeset version && node scripts/public-version.mjs",
-    "changeset:tag": "changeset tag"
+    "changeset:tag": "changeset git-tag"
   },
   "devDependencies": {
     "@adonisjs/fold": "^11.1.0",


### PR DESCRIPTION
## Description

The last release run tagged nothing and skipped `Package`, `NexusMods` and `Publish release`.

`changesets/action@v1` sets its `published` output by grepping `New tag:` out of the publish script's stdout. The Changesets v3 CLI prints clack output instead (`◇ Created git tags: - v5.9.0`), so `published` came back `false` even though the tag had been created locally, and every downstream job was skipped.

v2 replaces that stdout parsing with the report the CLI writes to `CHANGESETS_OUTPUT`, which `changeset git-tag` does emit.

- `changesets/action@v1` -> `@v2`
- inputs renamed to kebab-case: `version`/`publish`/`commit`/`title`/`createGithubReleases` -> `version-script`/`publish-script`/`commit-message`/`pr-title`/`create-github-releases`
- output `publishedPackages` -> `published-packages`, indexed as `outputs['published-packages']` so the expression parser does not read the dash as a subtraction
- dropped the `GITHUB_TOKEN` env: v2 no longer reads it, and the `github-token` input already defaults to `${{ github.token }}`
- `push-git-tags: true` spelled out: in v2 `create-github-releases: false` no longer implies tags are off, and the tag is what the jobs below check out
- dropped the `Push tag` step, the action pushes it now
- `changeset:tag` script: `changeset tag` -> `changeset git-tag`, the former is deprecated

## Notes

No changeset: CI only.

The 5.9.0 release commit was reverted off `main`, so the version PR is open again. Merging this first means that PR gets tagged with the fixed detection.